### PR TITLE
Correct license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ You can get the source code locally and contribute the the project.
 
 ## License
 
-[![Hex.pm](https://img.shields.io/hexpm/l/plug.svg)](./LICENSE.txt)
+[![Apache 2](https://img.shields.io/badge/license-Apache%202-blue.svg)](./LICENSE.txt)


### PR DESCRIPTION
@Chariyski I guess this is what you wanted to have. The current one is based on a Erlang project (https://hex.pm/packages/plug).

"https://img.shields.io/github/license/..." seems to be unresponsive atm, and as I guess the license won't change, this custom badge should be fine.