### PR TITLE
[FIX] Change property to empty value

### DIFF
--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -133,6 +133,15 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
             if (control) {
                 // Change the property through its setter
                 control['set' + property](newValue);
+
+                // Update properties and bindings
+                var controlProperties = ToolsAPI.getControlProperties(controlId);
+                var controlBindings = ToolsAPI.getControlBindings(controlId);
+                message.send({
+                    action: 'on-control-select',
+                    controlProperties: controlUtils.getControlPropertiesFormattedForDataView(controlId, controlProperties),
+                    controlBindings: controlUtils.getControlBindingsFormattedForDataView(controlBindings)
+                });
             }
         }
     };

--- a/app/scripts/modules/ui/helpers/DataViewHelper.js
+++ b/app/scripts/modules/ui/helpers/DataViewHelper.js
@@ -262,6 +262,8 @@ function _getCorrectedValue(value) {
 
     if (value === 'true' || value === 'false') {
         value = (value === 'true');
+    } else if (value === '') {
+        value = null;
     } else if (!isNaN(+value) && value !== null) {
         value = +value;
     }

--- a/tests/modules/ui/helpers/DataViewHelper.spec.js
+++ b/tests/modules/ui/helpers/DataViewHelper.spec.js
@@ -399,6 +399,10 @@ describe('Helpers for DataView', function () {
             var shouldReturnNull = DVHelper.getCorrectedValue(nil);
             expect(shouldReturnNull).to.equal(nil);
         });
+
+        it('should return null if empty string passed in', function () {
+            var shouldReturnEmpty = DVHelper.getCorrectedValue('');
+            expect(shouldReturnEmpty).to.equal(null);
+        });
     });
 });
-


### PR DESCRIPTION
This fixes the case when you clear the value of a property which
resulted into setting it to "0".
Now "null" will be used which set the property to the default value.

However this might not be the expected result (e.g. when the default
value is a string, which makes it impossible to clear it).

A way to explicitly reset a property value might be a better solution.