### PR TITLE
[FIX] Update control property

### DIFF
--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -130,19 +130,24 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
             var newValue = data.value;
 
             var control = sap.ui.getCore().byId(controlId);
-            if (control) {
+
+            if (!control) {
+                return;
+            }
+
+            try {
                 // Change the property through its setter
                 control['set' + property](newValue);
-
-                // Update properties and bindings
-                var controlProperties = ToolsAPI.getControlProperties(controlId);
-                var controlBindings = ToolsAPI.getControlBindings(controlId);
-                message.send({
-                    action: 'on-control-select',
-                    controlProperties: controlUtils.getControlPropertiesFormattedForDataView(controlId, controlProperties),
-                    controlBindings: controlUtils.getControlBindingsFormattedForDataView(controlBindings)
-                });
+            } catch (error) {
+                console.warn(error);
             }
+
+            // Update the DevTools with the actual property value of the control
+            this['do-control-select']({
+                detail: {
+                    target: controlId
+                }
+            });
         }
     };
 


### PR DESCRIPTION
After an error from setting a new value of a control property, the value should return back to the initial one.