### PR TITLE
[FIX] add support for ODataModel data display

### DIFF
--- a/app/vendor/ToolsAPI.js
+++ b/app/vendor/ToolsAPI.js
@@ -279,7 +279,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/library', 'sap/ui/Global', 'sap
                 if (bindingContextModel) {
                     model.mode = bindingContextModel.getDefaultBindingMode();
                     model.type = bindingContextModel.getMetadata().getName();
-                    model.data = bindingContextModel.getData ? bindingContextModel.getData() : undefined;
+                    model.data = bindingContextModel.getData ? bindingContextModel.getData('/') : undefined;
                 }
 
                 return model;


### PR DESCRIPTION
Hi all,

this commit allows for the display of Data in an ODataModel as its getData function call the internal getProperty-method, that needs an internal path. 
By calling this with the root path ("/") the whole data-object get fetched.