### PR TITLE
[FIX] Display of UI5 version for ABAP hosted apps

### DIFF
--- a/app/scripts/injected/detectUI5.js
+++ b/app/scripts/injected/detectUI5.js
@@ -23,7 +23,15 @@
                 responseToContentScriptBody.framework.version = '';
             }
             try {
-                responseToContentScriptBody.framework.name = sap.ui.getVersionInfo().gav.indexOf('openui5') !== -1 ? 'OpenUI5' : 'SAPUI5';
+                var frameworkInfo;
+                if (sap.ui.getVersionInfo().gav) {
+                    // Use group artifact version for maven built UI5
+                    frameworkInfo = sap.ui.getVersionInfo().gav;
+                } else {
+                    // Use name for others (like SAPUI5-on-ABAP)
+                    frameworkInfo = sap.ui.getVersionInfo().name;
+                }
+                responseToContentScriptBody.framework.name = frameworkInfo.indexOf('openui5') !== -1 ? 'OpenUI5' : 'SAPUI5';
             } catch (e) {
                 responseToContentScriptBody.framework.name = '';
             }

--- a/app/vendor/ToolsAPI.js
+++ b/app/vendor/ToolsAPI.js
@@ -14,7 +14,7 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/library', 'sap/ui/Global', 'sap
          * @private
          */
         function _getFrameworkName() {
-            var versionInfo;
+            var versionInfo, frameworkInfo;
 
             try {
                 versionInfo = sap.ui.getVersionInfo();
@@ -22,8 +22,15 @@ sap.ui.define(['jquery.sap.global', 'sap/ui/core/library', 'sap/ui/Global', 'sap
                 versionInfo = undefined;
             }
 
-            if (versionInfo && versionInfo.gav) {
-                return versionInfo.gav.indexOf('openui5') !== -1 ? 'OpenUI5' : 'SAPUI5';
+            if (versionInfo) {
+                if (versionInfo.gav) {
+                    // Use group artifact version for maven built UI5
+                    frameworkInfo = versionInfo.gav;
+                } else {
+                    // Use name for others (like SAPUI5-on-ABAP)
+                    frameworkInfo = versionInfo.name;
+                }
+               return frameworkInfo.indexOf('openui5') !== -1 ? 'OpenUI5' : 'SAPUI5';
             } else {
                 return '';
             }


### PR DESCRIPTION
For NetWeaver ABAP hosted UI5 applications, the sap-ui-version.json does not include any "gav" (group artifact version) property. Which lead to some issues displaying the frameworks name and version.

The sap-ui-version.json in those cases actually looks like this:
```json
{
    "name": "SAPUI5-on-ABAP",
    "version": "1.30.1",
    "buildTimestamp": "",
    "scmRevision": "",
    "libraries": [...]
}
```
---
I hereby offer a fix for the two issues I identified:
### Issue 1
In the popup, the core version is not displayed (although it got detected correctly):
![popup displays undefined for version](https://cloud.githubusercontent.com/assets/1589939/10245035/395f5b3a-6904-11e5-8bf8-9eb2e1e31584.png)
Because the ToolsAPI wasn't able to detect the frameworks name (as it was looking for the "gav" property) it returned an empty string. This lead to the version getting stored in the object poperty "<empty string>".
The popup however reads the version from either an  "OpenUI5" property, or from a "SAPUI5" property. Which both were undefined.
I added a fallback to the frameworks name (like "SAPUI5-on-ABAP") in cases "gav" is not available.


### Issue 2
The tooltip was missing the framework name (here "SAPUI5") as it couldn't be determined by detectUI5.js as it was also looking for the "gav" property.
![tooltip missing framwork name](https://cloud.githubusercontent.com/assets/1589939/10245042/561c44ea-6904-11e5-8764-fd946b5a8ca4.png)
I added a fallback to the frameworks name (like "SAPUI5-on-ABAP") in cases "gav" is not available.

---
Fixed popup:
![fixed popup](https://cloud.githubusercontent.com/assets/1589939/10245369/2d6367c4-6907-11e5-9af8-447ab28ee004.png)

