### PR TITLE
[FIX] DataView: show correct type info (supporting arrays)

### DIFF
--- a/app/scripts/modules/ui/DataView.js
+++ b/app/scripts/modules/ui/DataView.js
@@ -130,8 +130,13 @@ DataView.prototype._generateHTMLFromObject = function (key, currentElement) {
 
     html += DVHelper.wrapInTag(tag, key, {});
 
-    if (options.showTypeInfo === true) {
-        html += DVHelper.addKeyTypeInfo(currentElement);
+    if (options.showTypeInfo) {
+
+        if (!options.hideTitle) {
+            html += ':&nbsp;';
+        }
+
+        html += DVHelper.addKeyTypeInfoBegin(currentElement.data);
     }
 
     return html;
@@ -146,8 +151,8 @@ DataView.prototype._generateHTMLFromObject = function (key, currentElement) {
 DataView.prototype._generateHTMLForEndOfObject = function (currentElement) {
     var html = '';
 
-    if (currentElement.options.showTypeInfo === true && DVHelper.getObjectLength(currentElement.data)) {
-        html += DVHelper.wrapInTag('value', '}');
+    if (currentElement.options.showTypeInfo) {
+        html += DVHelper.addKeyTypeInfoEnd(currentElement.data);
     }
 
     return html;
@@ -201,6 +206,7 @@ DataView.prototype._generateHTMLSection = function (viewObject) {
     var associations = viewObject.associations;
     var html = '';
     var options = viewObject.options;
+    var isDataArray = Array.isArray(data);
 
     html += DVHelper.openUL(DVHelper.getULAttributesFromOptions(options));
 
@@ -218,6 +224,10 @@ DataView.prototype._generateHTMLSection = function (viewObject) {
             html += this._generateHTMLForKeyValuePair(key, DVHelper.formatValueForDataView(key, currentElement));
         } else {
             html += this._generateHTMLForKeyValuePair(key, viewObject);
+        }
+
+        if (isDataArray && key < data.length - 1) {
+            html += ',';
         }
 
         html += DVHelper.closeLI();

--- a/app/scripts/modules/ui/helpers/DataViewHelper.js
+++ b/app/scripts/modules/ui/helpers/DataViewHelper.js
@@ -122,17 +122,36 @@ function _valueNeedsQuotes(value, valueWrappedInHTML) {
  * @returns {string}
  * @private
  */
-function _addKeyTypeInfo(element) {
+function _addKeyTypeInfoBegin(element) {
 
     if (Array.isArray(element)) {
-        return ':&nbsp;' + '[' + _getObjectLength(element) + ']';
+        return '[';
     }
 
-    if (!_getObjectLength(element.data)) {
-        return ':&nbsp;' + '{}';
+    return '{';
+}
+
+/**
+ * @param {Array|Object} element
+ * @returns {string}
+ * @private
+ */
+function _addKeyTypeInfoEnd(element) {
+    var html = '';
+    var noOfElements = _getObjectLength(element);
+    var collapsedInfo = Array.isArray(element) ? noOfElements : '...';
+
+    if (noOfElements) {
+        html += _wrapInTag('collapsed-typeinfo', collapsedInfo);
     }
 
-    return ':&nbsp;' + '{';
+    if (Array.isArray(element)) {
+        html += ']';
+    } else {
+        html += '}';
+    }
+
+    return html;
 }
 
 /**
@@ -274,7 +293,8 @@ function _getCorrectedValue(value) {
 
 module.exports = {
     addArrow: _addArrow,
-    addKeyTypeInfo: _addKeyTypeInfo,
+    addKeyTypeInfoBegin: _addKeyTypeInfoBegin,
+    addKeyTypeInfoEnd: _addKeyTypeInfoEnd,
     closeLI: _closeLI,
     closeUL: _closeUL,
     findNearestDOMElement: _findNearestDOMElement,

--- a/app/styles/less/modules/DataView.less
+++ b/app/styles/less/modules/DataView.less
@@ -63,6 +63,10 @@ data-view {
             display: flex;
             flex-direction: column;
         }
+
+        & > ul[expanded] ~ collapsed-typeinfo {
+            display: none;
+        }
     }
 
     value[contentEditable=true]:focus {

--- a/tests/modules/ui/helpers/DataViewHelper.spec.js
+++ b/tests/modules/ui/helpers/DataViewHelper.spec.js
@@ -134,20 +134,32 @@ describe('Helpers for DataView', function () {
 
         it('should return the correct string with an array of values', function () {
             var array = ['one', 'two', 'three'];
-            var resultString = DVHelper.addKeyTypeInfo(array);
-            resultString.should.equal(':&nbsp;' + '[' + array.length + ']');
+            var resultString = DVHelper.addKeyTypeInfoBegin(array) + DVHelper.addKeyTypeInfoEnd(array);
+            resultString.should.equal('[<collapsed-typeinfo>' + array.length + '</collapsed-typeinfo>]');
+        });
+
+        it('should return the correct string with a simple array', function () {
+            var array = [];
+            var resultString = DVHelper.addKeyTypeInfoBegin(array) + DVHelper.addKeyTypeInfoEnd(array);
+            resultString.should.equal('[]');
+        });
+
+        it('should return the correct string with an DataView object (nested)', function () {
+            var DVObject = {data: {one: 1, two: 2, three: 3, bool: false}};
+            var resultString = DVHelper.addKeyTypeInfoBegin(DVObject) + DVHelper.addKeyTypeInfoEnd(DVObject);
+            resultString.should.equal('{<collapsed-typeinfo>...</collapsed-typeinfo>}');
         });
 
         it('should return the correct string with an DataView object', function () {
-            var DVObject = {data: {one: 1, two: 2, three: 3, bool: false}};
-            var resultString = DVHelper.addKeyTypeInfo(DVObject);
-            resultString.should.equal(':&nbsp;{');
+            var DVObject = {one: 1, two: 2, three: 3, bool: false};
+            var resultString = DVHelper.addKeyTypeInfoBegin(DVObject) + DVHelper.addKeyTypeInfoEnd(DVObject);
+            resultString.should.equal('{<collapsed-typeinfo>...</collapsed-typeinfo>}');
         });
 
-        it('should return an empty object string with a simple object', function () {
-            var DVObject = {one: 1, two: 2, three: 3, bool: false};
-            var resultString = DVHelper.addKeyTypeInfo(DVObject);
-            resultString.should.equal(':&nbsp;{}');
+        it('should return the correct string with a simple object', function () {
+            var DVObject = {};
+            var resultString = DVHelper.addKeyTypeInfoBegin(DVObject) + DVHelper.addKeyTypeInfoEnd(DVObject);
+            resultString.should.equal('{}');
         });
     });
 


### PR DESCRIPTION
The implementation for added typeinfo mixes currentElement and currentElement.data.

In `DVHelper._addKeyTypeInfo` is a check for `Array.isArray(element)`, which returns always false cause the provided element is an object with **options** - this is the condition in the DataView to get to the point where `DVHelper._addKeyTypeInfo` is called. Furthermore the functions checks the length of either the element itself or element.data dependent on the type, which is inconsistent.

With this fix it is possible to provide (nested) arrays that can be expanded/collapsed (if wanted). The array could contain sections (objects with an **options** entry) itself to enable more detailed nested views. If collapsed, the number of elements is shown. In case of an object, it will either show ellipsis if the object contains data.

![image](https://cloud.githubusercontent.com/assets/3205800/10263601/829ed9ba-69f4-11e5-95d3-033588d25c67.png)
**View of an (expanded) array object**

![image](https://cloud.githubusercontent.com/assets/3205800/10263602/90848674-69f4-11e5-9f8d-a04eea93aa8a.png)
**Collapsed array view**

![image](https://cloud.githubusercontent.com/assets/3205800/10263608/c26ff52e-69f4-11e5-8a5c-0ec209705bcc.png)
**View for an (expanded) object**

![image](https://cloud.githubusercontent.com/assets/3205800/10263612/ed0fd5d8-69f4-11e5-8079-2566562e1a0b.png)
**Collapsed object view**



