### PR TITLE
[FIX] DataView: toggleCollapse only if arrow tag is a direct child

### DIFF
--- a/app/scripts/modules/ui/helpers/DataViewHelper.js
+++ b/app/scripts/modules/ui/helpers/DataViewHelper.js
@@ -156,14 +156,15 @@ function _findNearestDOMElement(element, targetElementName) {
 
 /**
  * @param {element} target - HTML DOM element
+ * @returns {boolean}
  * @private
  */
 function _toggleCollapse(target) {
     var expandableLIChild = target.querySelector(':scope > ul');
-    var arrow = target.querySelector('arrow');
+    var arrow = target.querySelector(':scope > arrow');
 
     if (!arrow) {
-        return;
+        return false;
     }
 
     if (arrow.getAttribute('right') === 'true') {
@@ -177,6 +178,8 @@ function _toggleCollapse(target) {
 
         expandableLIChild.removeAttribute('expanded');
     }
+
+    return true;
 }
 
 /**

--- a/tests/modules/ui/helpers/DataViewHelper.spec.js
+++ b/tests/modules/ui/helpers/DataViewHelper.spec.js
@@ -181,23 +181,27 @@ describe('Helpers for DataView', function () {
     describe('#toggleCollapse', function () {
 
         var collapsableDOMStructure;
-        var liTag;
+        var collapsableLiTag;
+        var rootLiTag;
         var arrowTag;
         var ulTag;
+        var nestedUlTag;
 
         beforeEach(function () {
             collapsableDOMStructure = document.createDocumentFragment();
 
-            liTag = document.createElement('li');
-
+            rootLiTag = document.createElement('li');
+            ulTag = document.createElement('ul');
+            collapsableLiTag = document.createElement('li');
+            nestedUlTag = document.createElement('ul');
             arrowTag = document.createElement('arrow');
             arrowTag.setAttribute('right', 'true');
-            liTag.appendChild(arrowTag);
 
-            ulTag = document.createElement('ul');
-            liTag.appendChild(ulTag);
-
-            collapsableDOMStructure.appendChild(liTag);
+            rootLiTag.appendChild(ulTag);
+            ulTag.appendChild(collapsableLiTag);
+            collapsableLiTag.appendChild(arrowTag);
+            collapsableLiTag.appendChild(nestedUlTag);
+            collapsableDOMStructure.appendChild(rootLiTag);
         });
 
         afterEach(function () {
@@ -205,40 +209,57 @@ describe('Helpers for DataView', function () {
         });
 
         it('should set the arrow position to expanded (down)', function () {
-            // Setup
-            var targetDOMElement = collapsableDOMStructure.firstChild;
-            var arrowElement = targetDOMElement.querySelector('arrow');
-
             // Action
-            DVHelper.toggleCollapse(targetDOMElement);
+            var result = DVHelper.toggleCollapse(collapsableLiTag);
 
             // Assertion
-            arrowElement.getAttribute('down').should.equal('true');
+            expect(result).to.be.true;
+            arrowTag.getAttribute('down').should.equal('true');
         });
 
         it('should set the arrow position to collapsed (right)', function () {
             // Setup
-            var targetDOMElement = collapsableDOMStructure.firstChild;
-            var arrowElement = targetDOMElement.querySelector('arrow');
+            arrowTag.removeAttribute('right');
+            arrowTag.setAttribute('down', 'true');
 
             // Action
-            DVHelper.toggleCollapse(targetDOMElement);
+            var result = DVHelper.toggleCollapse(collapsableLiTag);
 
             // Assertion
-            arrowElement.getAttribute('down').should.equal('true');
+            expect(result).to.be.true;
+            arrowTag.getAttribute('right').should.equal('true');
         });
 
         it('should not find an arrow element', function () {
-            // Setup
-            var targetDOMElement = collapsableDOMStructure.firstChild;
-            var arrowElement = targetDOMElement.querySelector('arrow');
-            targetDOMElement.removeChild(arrowElement);
-
             // Action
-            var result = DVHelper.toggleCollapse(targetDOMElement);
+            var result = DVHelper.toggleCollapse(rootLiTag);
 
             // Assertion
-            expect(result).to.be.undefined;
+            expect(result).to.be.false;
+        });
+
+        it('should NOT change the arrow position to expanded (down)', function () {
+            // Action
+            var result = DVHelper.toggleCollapse(rootLiTag);
+
+            // Assertion
+            expect(result).to.be.false;
+            expect(arrowTag.getAttribute('down')).to.be.null;
+            arrowTag.getAttribute('right').should.equal('true');
+        });
+
+        it('should NOT change the arrow position to collapsed (right)', function () {
+            // Setup
+            arrowTag.removeAttribute('right');
+            arrowTag.setAttribute('down', 'true');
+
+            // Action
+            var result = DVHelper.toggleCollapse(rootLiTag);
+
+            // Assertion
+            expect(result).to.be.false;
+            expect(arrowTag.getAttribute('right')).to.be.null;
+            arrowTag.getAttribute('down').should.equal('true');
         });
     });
 


### PR DESCRIPTION
This commit fixes an issue that makes a parent section expandable if any child element is expandable.

![image](https://cloud.githubusercontent.com/assets/3205800/10263678/06e5948c-69f7-11e5-8b75-e8860b7508b1.png)
Clicking in the yellow area collapses the whole section cause the homeIcon entry is marked as expandable...

![image](https://cloud.githubusercontent.com/assets/3205800/10263675/dbf17de0-69f6-11e5-95cd-d21773d9f741.png)
... even though the main section itself is not marked as expandable (no arrow).