### PR TITLE
[FIX] ClickableValue: correct closing tag

### DIFF
--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -32,7 +32,7 @@ function ClickableValue(options) {
     // This is used for checking in the dataView
     this._isClickableValueForDataView = true;
     // This is shown in the data view
-    this.value = '<clickable-value key="' + options.key + '" parent="' + options.parent + '">' + options.value || '' + '</clickable-value>';
+    this.value = '<clickable-value key="' + options.key + '" parent="' + options.parent + '">' + (options.value || '') + '</clickable-value>';
     // This data is attached in the click event of the dataview
     this.eventData = options.eventData || {};
 }

--- a/tests/modules/ui/DataView.spec.js
+++ b/tests/modules/ui/DataView.spec.js
@@ -182,7 +182,7 @@ var clickableValueData = {
                         listMode: 'SingleSelectMaster'
                     }
                 },
-                value: '<clickable-value key="model" parent="counter">entity (TwoWay, JSONModel)',
+                value: '<clickable-value key="model" parent="counter">entity (TwoWay, JSONModel)</clickable-value>',
                 path: 'sampleCount',
                 type: 'int'
             }


### PR DESCRIPTION
Close 'clickable-value' tag was never added due missing parenthesis.