### PR TITLE
[FIX] CSS: remove duplicate scroll bars from outer containers

### DIFF
--- a/app/styles/less/modules/SplitContainer.less
+++ b/app/styles/less/modules/SplitContainer.less
@@ -22,7 +22,7 @@ splitter {
 
     & > start {
         display: flex;
-        overflow: auto;
+        overflow: hidden;
         position: relative;
         transform: translateZ(0);
         flex: 1;

--- a/app/styles/less/modules/TabBar.less
+++ b/app/styles/less/modules/TabBar.less
@@ -53,7 +53,7 @@ tabbar > tabs > tab[selected] {
 
 tabbar > contents {
     display: flex;
-    overflow-y: auto;
+    overflow: hidden;
     -webkit-transform: translateZ(0);
     flex: 1 1 0;
 }


### PR DESCRIPTION
SplitContainer/TabBar adds additional scrollbar (placeholder):

![image](https://cloud.githubusercontent.com/assets/3205800/12115456/d0620c8c-b3b2-11e5-97e3-b295ede98865.png)

![image](https://cloud.githubusercontent.com/assets/3205800/12115517/47bc977a-b3b3-11e5-8b34-10910d6784da.png)

Avoid overflow on ScrollContainer/TabBar children - the content is providing its own scrollbars.
