### PR TITLE
[FIX] SplitContainer: fix divider handling to calculate correct size

### DIFF
--- a/app/scripts/modules/ui/SplitContainer.js
+++ b/app/scripts/modules/ui/SplitContainer.js
@@ -197,19 +197,12 @@ SplitContainer.prototype.showEndContainer = function () {
  * @private
  */
 SplitContainer.prototype._mouseMoveHandler = function (event) {
-    var that = this;
-    var endContainerSize;
-    var windowWidth = window.innerWidth;
-    var windowHeight = window.innerHeight;
+    var splitContainerRect = this.$this.getBoundingClientRect();
 
-    if (that.isVerticalSplitter) {
-        endContainerSize = windowHeight - event.clientY;
-        that._$endElement.style.height = endContainerSize + 'px';
-        that._$startElement.style.height = (windowHeight - endContainerSize) + 'px';
+    if (this.isVerticalSplitter) {
+        this._$endElement.style.height = (splitContainerRect.top + splitContainerRect.height - event.clientY) + 'px';
     } else {
-        endContainerSize = windowWidth - event.clientX;
-        that._$endElement.style.width = endContainerSize + 'px';
-        that._$startElement.style.width = (windowWidth - endContainerSize) + 'px';
+        this._$endElement.style.width = (splitContainerRect.left + splitContainerRect.width - event.clientX) + 'px';
     }
 };
 

--- a/app/styles/less/modules/SplitContainer.less
+++ b/app/styles/less/modules/SplitContainer.less
@@ -22,10 +22,11 @@ splitter {
 
     & > start {
         display: flex;
-        overflow: auto;
+        overflow: hidden;
         position: relative;
         transform: translateZ(0);
-        flex: 1;
+        flex: auto;
+        min-width: 50px;
     }
 
     & > end {
@@ -34,6 +35,8 @@ splitter {
         position: relative;
         transform: translateZ(0);
         word-break: break-all;
+        flex: none;
+        min-width: 50px;
     }
 
     /* right */
@@ -113,7 +116,8 @@ splitter {
         flex-direction: column;
 
         & > start {
-            flex: 1;
+            min-width: 0;
+            min-height: 50px;
         }
 
         & > divider {
@@ -122,7 +126,9 @@ splitter {
         }
 
         & > end {
+            min-height: 50px;
             height: 400px;
+            min-width: 0;
             width: auto;
         }
 

--- a/tests/modules/ui/Splitter.spec.js
+++ b/tests/modules/ui/Splitter.spec.js
@@ -127,38 +127,34 @@ describe('Splitter', function () {
         afterEach(function () {
         });
 
-        it('should change the height of the end container', function () {
-            var expectedResult = window.innerHeight - 150 + 'px';
+        it('should change the style height of the end container', function () {
+            var splitterRect = splitter.$this.getBoundingClientRect();
+            var expectedResult = (splitterRect.top + splitterRect.height - mockEvent.clientY) + 'px';
 
             splitter._mouseMoveHandler(mockEvent);
 
             splitter._$endElement.style.height.should.be.equal(expectedResult);
         });
 
-        it('should change the height of the start container', function () {
-            var endContainerHeight = window.innerHeight - 150;
-            var expectedResult = window.innerHeight - endContainerHeight + 'px';
-
+        it('should not change the style height of the start container', function () {
             splitter._mouseMoveHandler(mockEvent);
 
-            splitter._$startElement.style.height.should.be.equal(expectedResult);
+            splitter._$startElement.style.height.should.be.equal('');
         });
 
-        it('should change the width of the end container', function () {
-            var expectedResult = window.innerWidth - 150 + 'px';
+        it('should change the style width of the end container', function () {
+            var horizontalSplitterRect = horizontalSplitter.$this.getBoundingClientRect();
+            var expectedResult = (horizontalSplitterRect.left + horizontalSplitterRect.width - mockEvent.clientX) + 'px';
 
             horizontalSplitter._mouseMoveHandler(mockEvent);
 
             horizontalSplitter._$endElement.style.width.should.be.equal(expectedResult);
         });
 
-        it('should change the width of the start container', function () {
-            var endContainerWidth = window.innerWidth - 150;
-            var expectedResult = window.innerWidth - endContainerWidth + 'px';
-
+        it('should not change the style width of the start container', function () {
             horizontalSplitter._mouseMoveHandler(mockEvent);
 
-            horizontalSplitter._$startElement.style.width.should.be.equal(expectedResult);
+            horizontalSplitter._$startElement.style.width.should.be.equal('');
         });
     });
 


### PR DESCRIPTION
Issue: Splitcontainer width/height is not adopted when re-sizing the developer window.

Solution: Only set the size of the end-container, size of start container is calculated automatically. Furthermore, the size is not calculated based on window dimensions anymore but dimensions of the split container itself.

![image](https://cloud.githubusercontent.com/assets/3205800/12115719/cfc34b0e-b3b4-11e5-8470-f9a0b008e6e5.png)

Mouse cursor was not captured on screenshot. Screenshot just points to the view where it can be seen/reproduced the easiest.
