### PR TITLE
[FIX] General: pre tag white-space changed to pre-wrap

### DIFF
--- a/app/styles/less/globals.less
+++ b/app/styles/less/globals.less
@@ -51,6 +51,7 @@ no-data {
 pre {
     display: inline;
     word-wrap: break-word;
+    white-space: pre-wrap;
 }
 
 section-title, value {


### PR DESCRIPTION
This happens without the fix:

![image](https://cloud.githubusercontent.com/assets/3205800/12918790/308ed636-cf41-11e5-8e0b-425398e9191e.png)
