### PR TITLE
Editable value fields extended for properties of enum type

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -101,5 +101,6 @@
         "that"
     ],
     "validateIndentation": 4,
+    "validateLineBreaks": "LF",
     "validateQuoteMarks": true
 }

--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -200,6 +200,39 @@ var controlProperties = (function () {
     var INHERITED = 'inherited';
 
     /**
+     * Formatter for global namespaced enum objects.
+     * @param {string} type
+     * @private
+     */
+    function _transformStringTypeToObject (type) {
+        var parts = type.split('.');
+        var obj = window;
+        var i;
+
+        for (i = 0; i < parts.length; i++) {
+            obj = obj[parts[i]];
+        }
+
+        return obj;
+    }
+
+    /**
+     * Formatter for the type enums.
+     * @param {string} type
+     * @private
+     */
+    function _formatTypes (type) {
+        var objectType;
+        if (sap.ui.base.DataType.getType(type).isEnumType()) {
+            objectType = _transformStringTypeToObject(type);
+        } else {
+            objectType = type;
+        }
+
+        return objectType;
+    }
+
+    /**
      * Formatter for the inherited properties.
      * @param {string} controlId
      * @param {Object} properties - UI5 control properties
@@ -222,8 +255,11 @@ var controlProperties = (function () {
                 title: title
             });
 
+            parent.types = {};
+
             for (var key in props) {
                 parent.data[key] = props[key].value;
+                parent.types[key]  =  props[key].type ? _formatTypes (props[key].type) : '';
             }
 
             var parentTitle = '<span gray>Inherits from</span>';
@@ -322,6 +358,7 @@ var controlProperties = (function () {
 
         var title = properties[OWN].meta.controlName;
         var props = properties[OWN].properties;
+        var types = {};
 
         for (var key in props) {
             if (props[key].type === 'object') {
@@ -329,6 +366,7 @@ var controlProperties = (function () {
                 continue;
             }
 
+            types[key] = props[key].type ? _formatTypes (props[key].type) : '';
             props[key] = props[key].value;
         }
 
@@ -338,6 +376,7 @@ var controlProperties = (function () {
             title: title
         });
         properties[OWN].data = props;
+        properties[OWN].types = types;
         properties[OWN].options.title = '#' + controlId + ' <span gray>(' + title + ')</span>';
 
         _formatInheritedProperties(controlId, properties);

--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -201,7 +201,7 @@ var controlProperties = (function () {
 
     /**
      * Formatter for global namespaced enum objects.
-     * @param {string} type
+     * @param {string | Object} type
      * @private
      */
     function _transformStringTypeToObject (type) {
@@ -210,7 +210,7 @@ var controlProperties = (function () {
         var i;
 
         for (i = 0; i < parts.length; i++) {
-            obj = obj[parts[i]];
+            obj = obj[parts[i]] ? obj[parts[i]] : '';
         }
 
         return obj;
@@ -218,12 +218,12 @@ var controlProperties = (function () {
 
     /**
      * Formatter for the type enums.
-     * @param {string} type
+     * @param {string | Object} type
      * @private
      */
     function _formatTypes (type) {
         var objectType;
-        if (sap.ui.base.DataType.getType(type).isEnumType()) {
+        if (type.startsWith('sap.') && sap.ui.base.DataType.getType(type).getDefaultValue()) {
             objectType = _transformStringTypeToObject(type);
         } else {
             objectType = type;

--- a/app/scripts/modules/ui/DataView.js
+++ b/app/scripts/modules/ui/DataView.js
@@ -169,6 +169,7 @@ DataView.prototype._generateHTMLForKeyValuePair = function (key, currentView) {
     var html = '';
     var value = currentView.data[key];
     var options = currentView.options;
+    var type = currentView.types ? currentView.types[key] : '';
     var attributes = {};
     var valueHTML;
 
@@ -182,6 +183,8 @@ DataView.prototype._generateHTMLForKeyValuePair = function (key, currentView) {
 
     if (value && typeof value === 'object') {
         valueHTML = JSONFormatter.formatJSONtoHTML(value);
+    } else if (typeof type === 'object') {
+        valueHTML = DVHelper.valueNeedsQuotes(value, DVHelper.wrapInSelectTag(value, attributes, type));
     } else {
         valueHTML = DVHelper.valueNeedsQuotes(value, DVHelper.wrapInTag('value', value, attributes));
     }
@@ -349,6 +352,9 @@ DataView.prototype._onClickHandler = function () {
             });
         }
 
+        if (targetElement.nodeName === 'SELECT') {
+            that._onChangeHandler(targetElement);
+        }
     };
 };
 
@@ -413,6 +419,43 @@ DataView.prototype._onBlurHandler = function (target) {
         that.onPropertyUpdated(propertyData);
 
         target.removeEventListener('onblur', this);
+        that._selectValue = true;
+    };
+};
+
+/**
+ * Change event handler for the selectable values.
+ * @param {element} target - HTML DOM element
+ * @private
+ */
+DataView.prototype._onChangeHandler = function (target) {
+    var that = this;
+
+    if (!target) {
+        return;
+    }
+
+    /**
+     * Handler for change event.
+     * @param {Object} e
+     */
+    target.onchange = function (e) {
+        var propertyData = {};
+        var target = e.target;
+        var propertyName;
+        var value;
+
+        propertyData.controlId = target.getAttribute('data-control-id');
+
+        propertyName = target.getAttribute('data-property-name');
+        propertyData.property = propertyName.charAt(0).toUpperCase() + propertyName.slice(1);
+
+        value = target.selectedOptions[0].value;
+        propertyData.value = DVHelper.getCorrectedValue(value);
+
+        that.onPropertyUpdated(propertyData);
+
+        target.removeEventListener('onchange', this);
         that._selectValue = true;
     };
 };

--- a/app/scripts/modules/ui/helpers/DataViewHelper.js
+++ b/app/scripts/modules/ui/helpers/DataViewHelper.js
@@ -82,6 +82,32 @@ function _addArrow(isExpanded) {
 }
 
 /**
+ * Adding 'select' HTML Element options with data for the property variations.
+ * @param {string} value
+ * @param {Object} type
+ * @returns {string}
+ * @private
+ */
+function _generateValueOptions(value, type) {
+    var html = '';
+    var types;
+    var i;
+
+    if (Object.keys(type).length)
+    {
+        types = Object.keys(type);
+
+        for (i = 0; i < types.length; i++) {
+            html += '<option value="' + type[types[i]] + '"' + (type[types[i]] === value ? ' selected' : '') + '>' +
+                types[i] + '</option>';
+        }
+
+    }
+
+    return html;
+}
+
+/**
  * @param {string} tag - name of HTML tag
  * @param {string|number|boolean} value
  * @param {Object} attributes
@@ -98,6 +124,22 @@ function _wrapInTag(tag, value, attributes) {
     html += '<' + tag;
     html += _generateTagAttributes(attributes);
     html += '>' + value + '</' + tag + '>';
+    return html;
+}
+
+/**
+ * @param {string|number|boolean} value
+ * @param {Object} attributes
+ * @param {Object} type - predefined type
+ * @returns {string}
+ * @private
+ */
+function _wrapInSelectTag (value, attributes, type) {
+    var html = '';
+
+    html += '<select';
+    html += _generateTagAttributes(attributes);
+    html += '>' + (type ? _generateValueOptions(value, type) : value) + '</select>';
     return html;
 }
 
@@ -329,5 +371,6 @@ module.exports = {
     selectEditableContent: _selectEditableContent,
     toggleCollapse: _toggleCollapse,
     wrapInTag: _wrapInTag,
+    wrapInSelectTag: _wrapInSelectTag,
     valueNeedsQuotes: _valueNeedsQuotes
 };

--- a/tests/modules/ui/DataView.spec.js
+++ b/tests/modules/ui/DataView.spec.js
@@ -52,6 +52,57 @@ var mockDataWithNestedObject = {
     }
 };
 
+var mockDataWithTypes = {
+
+    'properties': {
+        'options': {
+            'title': '<anchor>#__button0</anchor> (sap.m.Button)',
+            'expandable': true,
+            'editableValues': true,
+            'showTypeInfo': true,
+            'controlId': 'button_0'
+        },
+        'data': {
+            'title': 'Simple Form',
+            'description': '',
+            'icon': '',
+            'iconInset': true,
+            'iconDensityAware': true,
+            'activeIcon': 'sap://icon',
+            'infoState': 'None',
+            'adaptTileSize': true,
+            'titleTextDirection': 'inherit',
+            'infoTextDirection': 'inherit',
+            'moreData': mockDataViewFormattedObject
+        },
+        'types': {
+            'title': 'string',
+            'description': 'string',
+            'icon': 'string',
+            'iconInset': 'boolean',
+            'iconDensityAware': 'boolean',
+            'activeIcon': 'string',
+            'infoState': 'sap.ui.core.ValueState',
+            'adaptTileSize': 'boolean',
+            'titleTextDirection': {
+                Inherit: 'Inherit',
+                LTR: 'LTR',
+                RTL: 'RTL'
+            },
+            'infoTextDirection': {
+                Inherit: 'Inherit',
+                LTR: 'LTR',
+                RTL: 'RTL'
+            },
+            'moreData': 'object'
+        },
+        associations: {
+            ariaDescribedBy: 'sap.ui.core.Control',
+            ariaLabelledBy: 'sap.ui.core.Control'
+        }
+    }
+};
+
 var mockDataWithPropertiesInfo = {
     'properties': {
         'options': {
@@ -705,6 +756,35 @@ describe('DataView', function () {
 
             it('should call on blur handler without target', function () {
                 sampleView._onBlurHandler();
+            });
+        });
+
+        describe('_changeHandler', function () {
+            var sampleView;
+            var blurHandlerSpy;
+            var changeHandlerSpy;
+            var dataViewElement;
+            var editableElements;
+            var selectBox;
+
+            beforeEach(function () {
+                sampleView = new DataViewComponent('data-view');
+                sampleView.setData(mockDataWithTypes);
+                dataViewElement = document.getElementById('data-view');
+                blurHandlerSpy = sinon.spy(DataViewComponent.prototype, '_onBlurHandler');
+                changeHandlerSpy = sinon.spy(DataViewComponent.prototype, '_onChangeHandler');
+                selectBox = dataViewElement.querySelector('select');
+            });
+
+            afterEach(function () {
+                dataViewElement = null;
+                blurHandlerSpy.restore();
+                changeHandlerSpy.restore();
+            });
+
+            it('should not trigger blur handler', function () {
+                selectBox.dispatchEvent(new Event('change'));
+                expect(blurHandlerSpy.notCalled).to.equal(true);
             });
         });
 


### PR DESCRIPTION
It would be helpful to have visual presentation of what other options are when it comes to control properties of UI5 enum types. In this change they are added as options in a select box and can be changed dynamically. It is gaining better user experience.