### PR TITLE
corrected field

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -3,7 +3,7 @@
     "name": "UI5 Inspector",
     "version": "0.9.9",
     "background": {
-        "persistence": false,
+        "persistent": false,
         "scripts": [
             "/scripts/background/main.js"
         ]


### PR DESCRIPTION
Problem:
The manifest contains a property name "persistence" that is not defined in the manifest file format specification: https://developer.chrome.com/docs/extensions/mv2/manifest/

Solution:
Corrected to the standard name "persistent" as defined in the manifest file format specification.