### PR TITLE
feat: new contextMenu item for copying HTML is created

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -35,7 +35,8 @@
     "permissions": [
         "scripting",
         "contextMenus",
-        "activeTab"
+        "activeTab",
+        "clipboardWrite"
     ],
     "host_permissions": [
         "http://*/*",

--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -11,6 +11,12 @@
         contexts: ['all']
     });
 
+    var contextMenuCopyHtml = new ContextMenu({
+        title: 'Copy HTML',
+        id: 'context-menu-copy-html',
+        contexts: ['all']
+    });
+
     /**
      * This method will be fired when an instanced is clicked. The idea is to be overwritten from the instance.
      * @param {Object} info - Information sent when a context menu item is clicked. Check chrome.contextMenus.onClicked.
@@ -18,7 +24,19 @@
      */
     contextMenu.onClicked = function (info, tab) {
         utils.sendToAll({
-            action: 'on-contextMenu-control-select',
+            action: 'do-context-menu-control-select',
+            target: contextMenu._rightClickTarget
+        }, tab.id);
+    };
+
+    /**
+     * This method will be fired when an instanced is clicked. The idea is to be overwritten from the instance.
+     * @param {Object} info - Information sent when a context menu item is clicked. Check chrome.contextMenus.onClicked.
+     * @param {Object} tab - The details of the tab where the click took place.
+     */
+     contextMenuCopyHtml.onClicked = function (info, tab) {
+        utils.sendToAll({
+            action: 'do-context-menu-copy-html',
             target: contextMenu._rightClickTarget
         }, tab.id);
     };
@@ -84,6 +102,7 @@
          */
         'on-ui5-devtool-show': function (message) {
             contextMenu.create();
+            contextMenuCopyHtml.create();
         },
 
         /**
@@ -92,6 +111,7 @@
          */
         'on-ui5-devtool-hide': function (message) {
             contextMenu.removeAll();
+            contextMenuCopyHtml.removeAll();
         }
     };
 

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -62,6 +62,30 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     mutation.init();
 
     /**
+     * Writes HTML content of a Control in the user's clipboard
+     * @param {String} text
+     * @private
+     */
+    function _writeInClipboardFromDevTools(text) {
+        return new Promise((resolve, reject) => {
+            var _asyncCopyFn = (async () => {
+                try {
+                    var value = await navigator.clipboard.writeText(text);
+                    resolve(value);
+                } catch (e) {
+                    reject(e);
+                }
+                window.removeEventListener("focus", _asyncCopyFn);
+            });
+
+            window.addEventListener("focus", _asyncCopyFn);
+
+            var event = new Event("focus");
+            window.dispatchEvent(event);
+        });
+    };
+
+    /**
      * Sets control's property.
      * @param {Object} oControl
      * @param {Object} oData - property's data
@@ -225,6 +249,40 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
                     target: sControlId
                 }
             });
+        },
+
+        /**
+         * Selects Control with context menu click.
+         * @param {Object} event
+         */
+        'do-context-menu-control-select': function (event) {
+            message.send({
+                action: 'on-contextMenu-control-select',
+                target: event.detail.target
+            });
+        },
+
+        /**
+         * Copies HTML of Control with context menu click.
+         * @param {Object} event
+         */
+        'do-context-menu-copy-html': function (event) {
+            var elementID = event.detail.target,
+                navigatorClipBoard = navigator && navigator.clipboard,
+                selectedElement;
+
+            if (typeof elementID !== 'string') {
+                console.warn('Please use a valid string parameter');
+                return;
+            }
+
+            if (!navigatorClipBoard) {
+                console.warn('This functionality is not enabled');
+                return;
+            }
+
+            selectedElement = document.getElementById(elementID);
+            _writeInClipboardFromDevTools(selectedElement.outerHTML);
         }
     };
 

--- a/app/scripts/modules/background/ContextMenu.js
+++ b/app/scripts/modules/background/ContextMenu.js
@@ -1,5 +1,5 @@
 'use strict';
-
+var oContextMenusCreated = {};
 /**
  * Context menu.
  * @param {Object} options
@@ -26,13 +26,16 @@ function ContextMenu(options) {
 ContextMenu.prototype.create = function () {
     var that = this;
 
-    chrome.contextMenus.create({
-        title: that._title,
-        id: that._id,
-        contexts: that._contexts
-    });
+    if (!oContextMenusCreated[that._id]) {
+        chrome.contextMenus.create({
+            title: that._title,
+            id: that._id,
+            contexts: that._contexts
+        });
 
-    chrome.contextMenus.onClicked.addListener(that._onClickHandler.bind(that));
+        chrome.contextMenus.onClicked.addListener(that._onClickHandler.bind(that));
+        oContextMenusCreated[that._id] = true;
+    }
 };
 
 /**
@@ -40,6 +43,7 @@ ContextMenu.prototype.create = function () {
  */
 ContextMenu.prototype.removeAll = function () {
     chrome.contextMenus.removeAll();
+    oContextMenusCreated = {};
 };
 
 /**

--- a/app/scripts/modules/ui/ControlTree.js
+++ b/app/scripts/modules/ui/ControlTree.js
@@ -149,6 +149,18 @@ function _findNearestDOMParent(element, parentNodeName) {
 }
 
 /**
+ * Enables the Copy HTML contextMenu when focus of the ControlTree's window is lost
+ * @private
+ */
+function _onWindowFocusLost () {
+    chrome.contextMenus.update('context-menu-copy-html', {
+        enabled: true
+    });
+
+    window.removeEventListener(_onWindowFocusLost);
+}
+
+/**
  * ControlTree constructor.
  * @param {string} id - The id of the DOM container
  * @param {ControlTree} instantiationOptions
@@ -591,6 +603,13 @@ ControlTree.prototype._onTreeElementMouseHover = function (event) {
  */
 ControlTree.prototype._createHandlers = function () {
     this._treeContainer.onclick = this._onArrowClick.bind(this);
+    this._treeContainer.addEventListener("contextmenu", function () {
+        chrome.contextMenus.update('context-menu-copy-html', {
+            enabled: false
+        });
+
+        window.addEventListener("blur", _onWindowFocusLost);
+    });
     this._filterContainer.onkeyup = this._onSearchInput.bind(this);
     this._filterContainer.onsearch = this._onSearchEvent.bind(this);
     this._filterContainer.onchange = this._onOptionsChange.bind(this);


### PR DESCRIPTION
The new contextMenu item - Copy HTML, is now enabled for the web page.
When user does right click mouse button on a Control in the page, he now
can choose to copy the HTML of the pressed Control. The HTML goes in his
clipboard.