### PR TITLE
fix: fixed UI5 version detection

### DIFF
--- a/app/scripts/injected/detectUI5.js
+++ b/app/scripts/injected/detectUI5.js
@@ -20,7 +20,7 @@
 
             // Get framework version
             try {
-                responseToContentScriptBody.framework.version = sap.ui.getVersionInfo().version;
+                responseToContentScriptBody.framework.version = sap.ui.getCore().getConfiguration().getVersion().toString();
             } catch (e) {
                 responseToContentScriptBody.framework.version = '';
             }

--- a/app/vendor/ToolsAPI.js
+++ b/app/vendor/ToolsAPI.js
@@ -65,7 +65,7 @@ sap.ui.define(["jquery.sap.global", "sap/ui/core/ElementMetadata"],
             return {
                 commonInformation: {
                     frameworkName: _getFrameworkName(oVersionInfo.name),
-                    version: oVersionInfo.version,
+                    version: sap.ui.getCore().getConfiguration().getVersion().toString(),
                     buildTime: oVersionInfo.buildTimestamp,
                     userAgent: navigator.userAgent,
                     applicationHREF: window.location.href,
@@ -621,9 +621,8 @@ sap.ui.define(["jquery.sap.global", "sap/ui/core/ElementMetadata"],
 
         var elementRegistry = {
             getRegisteredElements: function () {
-                var oVersionInfo = sap.ui.getVersionInfo(),
-                    iVersion = parseInt(oVersionInfo.version.substring(2)),
-                    isSupported = iVersion >= 67,
+                var iFrameWorkMinorVersion = sap.ui.getCore().getConfiguration().getVersion().getMinor(),
+                    isSupported = iFrameWorkMinorVersion >= 67,
                     aRegisteredElements = [],
                     oElements;
 


### PR DESCRIPTION
Problem: When the inspected app is built the UI5 Tooling, the version
which we take from the "sap.ui.getVersionInfo" API is incorrect.
This results in some unwanted behavior in the "Event Registry" tab of
the inspector.

Solution: We take the framework version from the framework's core
configuration which always returns the correct data.