### PR TITLE
fix: remove invalid parameter

### DIFF
--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -28,7 +28,7 @@
             target: contextMenu._rightClickTarget,
             // specify the frame in which the user clicked
             frameId: info.frameId
-        }, tab.id);
+        });
     };
 
     /**
@@ -41,7 +41,7 @@
             action: 'do-context-menu-copy-html',
             target: contextMenu._rightClickTarget,
             frameId: info.frameId
-        }, tab.id);
+        });
     };
 
     // Name space for message handler functions.

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -547,7 +547,8 @@
          */
         'on-ui5-not-detected': function (message, messageSender) {
             frameData[messageSender.frameId] = {
-                isUI5Detected: false
+                isUI5Detected: false,
+                url: messageSender.url
             };
             framesSelect.setData(frameData);
             if (framesSelect.getSelectedId() === messageSender.frameId) {


### PR DESCRIPTION
1) Remove invalid parameter passed to the utils.sendToAll function that called an "invalid signature" error from chrome
2) Ensured that the iframe URL is shown in the frames dropdown even the iframe has no UI5 content