### PR TITLE
feat: show XML of XMLViews in elements registry

### DIFF
--- a/app/html/panel/ui5/index.html
+++ b/app/html/panel/ui5/index.html
@@ -119,6 +119,7 @@
                                     </tab>
                                     <tab id="elements-registry-tab-aggregations">Aggregations</tab>
                                     <tab id="elements-registry-tab-events">Events</tab>
+                                    <tab id="elements-registry-tab-xmlview">XML View</tab>
                                 </tabs>
                                 <contents>
                                     <content for="elements-registry-tab-properties">
@@ -139,6 +140,9 @@
                                     </content>
                                     <content for="elements-registry-tab-events">
                                         <data-view id="elements-registry-control-events"></data-view>
+                                    </content>
+                                    <content for="elements-registry-tab-xmlview">
+                                        <xml-view id="elements-registry-control-xmlview"></xml-view>
                                     </content>
                                 </contents>
                             </tabbar>

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -21,6 +21,7 @@
     var Splitter = require('../../../modules/ui/SplitContainer.js');
     var ODataDetailView = require('../../../modules/ui/ODataDetailView.js');
     var ODataMasterView = require('../../../modules/ui/ODataMasterView.js');
+    var XMLDetailView = require('../../../modules/ui/XMLDetailView.js');
     var OElementsRegistryMasterView = require('../../../modules/ui/OElementsRegistryMasterView.js');
 
     // Apply theme
@@ -220,7 +221,10 @@
         }
     });
 
+    // XML visualization for XML Views
+    var oXMLDetailView = new XMLDetailView('elements-registry-control-xmlview');
     var oElementsRegistryMasterView = new OElementsRegistryMasterView('elements-registry-tab-master', {
+        XMLDetailView: oXMLDetailView,
         /**
          * Method fired when a Control is selected.
          * @param {string} sControlId

--- a/app/scripts/modules/ui/OElementsRegistryMasterView.js
+++ b/app/scripts/modules/ui/OElementsRegistryMasterView.js
@@ -124,6 +124,7 @@ function OElementsRegistryMasterView(domId, options) {
 
     this.oContainerDOM = document.getElementById(domId);
     this.sNotSupportedMessage = '<h1>Current version of OpenUI5/SAPUI5 doesn\'t support element registry</h1>';
+    this.XMLDetailView = options.XMLDetailView;
 
     /**
      * Selects an element.
@@ -522,6 +523,7 @@ OElementsRegistryMasterView.prototype.sortHandler = function () {
  */
 OElementsRegistryMasterView.prototype.selectHandler = function (oEvent) {
     this.onSelectItem(oEvent.data._data.id);
+    this.XMLDetailView.update(oEvent.data._data);
     this._sSelectedItem = oEvent.data._data.id;
 };
 

--- a/app/scripts/modules/ui/XMLDetailView.js
+++ b/app/scripts/modules/ui/XMLDetailView.js
@@ -1,0 +1,85 @@
+/* globals ResizeObserver */
+
+'use strict';
+const formatXML = require('prettify-xml');
+const NOXMLVIEWMESSAGE = 'Select a \'sap.ui.core.mvc.XMLView\' to see its XML content. Click to filter on XMLViews';
+
+/**
+ * @param {string} containerId - id of the DOM container
+ * @constructor
+ */
+function XMLDetailView(containerId) {
+    this.oContainer = document.getElementById(containerId);
+    this.oEditorDOM = document.createElement('div');
+    this.oEditorDOM.id = 'xmlEditor';
+    this.oEditorDOM.classList.toggle('hidden', true);
+    this.oContainer.appendChild(this.oEditorDOM);
+
+    this.oEditorAltDOM = document.createElement('div');
+    this.oEditorAltDOM.classList.add('editorAlt');
+    this.oEditorAltDOM.classList.toggle('hidden', false);
+    this.oEditorAltMessageDOM = document.createElement('div');
+    this.oEditorAltMessageDOM.innerText = NOXMLVIEWMESSAGE;
+
+    this.oEditorAltMessageDOM.addEventListener('click', function() {
+        var searchField = document.getElementById('elementsRegistrySearch');
+        var filterCheckbox = document.getElementById('elementsRegistryCheckbox');
+        searchField.value = 'sap.ui.core.mvc.XMLView';
+        if (!filterCheckbox.checked) {
+            filterCheckbox.click();
+        }
+        return false;
+    });
+    this.oContainer.appendChild(this.oEditorAltDOM);
+    this.oEditorAltDOM.appendChild(this.oEditorAltMessageDOM);
+
+    this.oEditor = ace.edit(this.oEditorDOM.id);
+    this.oEditor.getSession().setUseWrapMode(true);
+
+    this._setTheme();
+
+    const oResizeObserver = new ResizeObserver(function () {
+        this.oEditor.resize();
+    }.bind(this));
+    oResizeObserver.observe(this.oEditorDOM);
+}
+
+/**
+ * Updates data.
+ * @param {Object} data - object structure as JSON
+ */
+XMLDetailView.prototype.update = function (data) {
+    const xml = data.xml && formatXML(data.xml);
+    let sAltMessage;
+
+    this.oEditorDOM.classList.toggle('hidden', !xml);
+    this.oEditorAltDOM.classList.toggle('hidden', !!xml);
+
+    if (xml) {
+        this.oEditor.session.setMode('ace/mode/xml');
+        this.oEditor.setValue(xml, 0);
+    } else {
+        sAltMessage = data.altMessage || NOXMLVIEWMESSAGE;
+        this.oEditorAltMessageDOM.innerText = sAltMessage;
+    }
+
+    this.oEditor.clearSelection();
+};
+
+/**
+ * Clears editor.
+ */
+XMLDetailView.prototype.clear = function () {
+    this.oEditor.setValue('', -1);
+};
+
+/**
+ * Sets theme.
+ */
+XMLDetailView.prototype._setTheme = function () {
+    var bDarkMode = chrome.devtools.panels.themeName === 'dark';
+
+    this.oEditor.setTheme(bDarkMode ? 'ace/theme/vibrant_ink' : 'ace/theme/chrome');
+};
+
+module.exports = XMLDetailView;

--- a/app/styles/less/modules/XMLView.less
+++ b/app/styles/less/modules/XMLView.less
@@ -1,0 +1,25 @@
+xml-view {
+    height: 100%;
+}
+
+#elements-registry-control-xmlview {
+    .editorAlt {
+        display: flex;
+        div {
+            margin: auto;
+        }
+    }
+
+    div.hidden {
+        visibility: hidden;
+    }
+
+    .editorAlt, #xmlEditor {
+        position: absolute;
+        top: 25px;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        height: auto;
+    }
+}

--- a/app/styles/less/modules/XMLView.less
+++ b/app/styles/less/modules/XMLView.less
@@ -7,6 +7,7 @@ xml-view {
         display: flex;
         div {
             margin: auto;
+            cursor: pointer;
         }
     }
 

--- a/app/styles/less/themes/base/base.less
+++ b/app/styles/less/themes/base/base.less
@@ -13,6 +13,7 @@
 @import "../../modules/SplitContainer.less";
 @import "../../modules/JSONView.less";
 @import "../../modules/ODataView.less";
+@import "../../modules/XMLView.less";
 @import "../../modules/DataGrid.less";
 @import "../../modules/ElementsRegistry.less";
 

--- a/app/vendor/ToolsAPI.js
+++ b/app/vendor/ToolsAPI.js
@@ -630,15 +630,17 @@ sap.ui.define(["jquery.sap.global", "sap/ui/core/ElementMetadata"],
                     oElements = sap.ui.core.Element.registry.all();
 
                     Object.keys(oElements).forEach(function (sKey) {
-                        var oParent = oElements[sKey].getParent();
+                        var oElement = oElements[sKey];
+                        var oParent = oElement.getParent();
 
                         aRegisteredElements.push({
-                            id: oElements[sKey].getId(),
-                            type: oElements[sKey].getMetadata().getName(),
-                            isControl: oElements[sKey].isA("sap.ui.core.Control"),
-                            isRendered: oElements[sKey].isActive(),
+                            id: oElement.getId(),
+                            type: oElement.getMetadata().getName(),
+                            isControl: oElement.isA("sap.ui.core.Control"),
+                            isRendered: oElement.isActive(),
                             parentId: oParent && (oParent.isA("sap.ui.core.Control") || oParent.isA("sap.ui.core.Element")) ? oParent.getId() : '',
-                            aggregation: oElements[sKey].sParentAggregationName ? oElements[sKey].sParentAggregationName : ''
+                            aggregation: oElement.sParentAggregationName ? oElement.sParentAggregationName : '',
+                            xml: oElement._xContent && (new XMLSerializer()).serializeToString(oElement._xContent)
                         })
                     });
                 }

--- a/tests/styles/themes/dark/dark.css
+++ b/tests/styles/themes/dark/dark.css
@@ -797,6 +797,27 @@ odata-detail-view {
   border: none;
   white-space: pre;
 }
+xml-view {
+  height: 100%;
+}
+#elements-registry-control-xmlview .editorAlt {
+  display: flex;
+}
+#elements-registry-control-xmlview .editorAlt div {
+  margin: auto;
+}
+#elements-registry-control-xmlview div.hidden {
+  visibility: hidden;
+}
+#elements-registry-control-xmlview .editorAlt,
+#elements-registry-control-xmlview #xmlEditor {
+  position: absolute;
+  top: 25px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
 /*
  * Copyright (C) 2008 Apple Inc. All Rights Reserved.
  *

--- a/tests/styles/themes/dark/dark.css
+++ b/tests/styles/themes/dark/dark.css
@@ -805,6 +805,7 @@ xml-view {
 }
 #elements-registry-control-xmlview .editorAlt div {
   margin: auto;
+  cursor: pointer;
 }
 #elements-registry-control-xmlview div.hidden {
   visibility: hidden;

--- a/tests/styles/themes/light/light.css
+++ b/tests/styles/themes/light/light.css
@@ -797,6 +797,27 @@ odata-detail-view {
   border: none;
   white-space: pre;
 }
+xml-view {
+  height: 100%;
+}
+#elements-registry-control-xmlview .editorAlt {
+  display: flex;
+}
+#elements-registry-control-xmlview .editorAlt div {
+  margin: auto;
+}
+#elements-registry-control-xmlview div.hidden {
+  visibility: hidden;
+}
+#elements-registry-control-xmlview .editorAlt,
+#elements-registry-control-xmlview #xmlEditor {
+  position: absolute;
+  top: 25px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: auto;
+}
 /*
  * Copyright (C) 2008 Apple Inc. All Rights Reserved.
  *

--- a/tests/styles/themes/light/light.css
+++ b/tests/styles/themes/light/light.css
@@ -805,6 +805,7 @@ xml-view {
 }
 #elements-registry-control-xmlview .editorAlt div {
   margin: auto;
+  cursor: pointer;
 }
 #elements-registry-control-xmlview div.hidden {
   visibility: hidden;


### PR DESCRIPTION
## New `XML View` tab in `Elements Registry` showing XMLView content

This PR introduces a new feature for the `Elements Registry` for `sap.ui.core.mvc.XMLView` controls. It provides easy access to the definition of an XMLView. 

XMLViews may be bundled and minified in a component or library preload and therefor not easy to read. On top of that SAP Fiori elements is generating XMLViews dynamically based on OData metadata.

### Usage

* Select the tab `Elements Registry`
* Search and / filter for `XMLView` or `sap.ui.core.mvc.XMLView`
* Select any control of that type
* Select the tab `XML View` in the details area

The XML of the selected XMLView will be shown.

### Screenshot 

<img width="1894" alt="image" src="https://user-images.githubusercontent.com/11347561/201975072-a1d2c495-23db-4c49-ac1b-09c44ec8a456.png">
