### PR TITLE
fix: allow selection of element by id with special chars

### DIFF
--- a/app/scripts/modules/ui/ControlTree.js
+++ b/app/scripts/modules/ui/ControlTree.js
@@ -283,7 +283,7 @@ ControlTree.prototype.setSelectedElement = function (elementID) {
         return;
     }
 
-    selectedElement = this._controlTreeContainer.querySelector('#' + elementID);
+    selectedElement = this._controlTreeContainer.querySelector(`[id="${elementID}"]`);
 
     if (selectedElement === null) {
         console.warn('The selected element is not a child of the ControlTree');


### PR DESCRIPTION
Problem: Error from querySelector when called with element id that contains special characters. 
Sample: https://jsbin.com/suhovumigu/1/edit?html,js,output shows that querySelector throws error when called with id string that contains "::", as used in many apps
Solution: applied the recommended selector format
