### PR TITLE
feat: copy control to console

### DIFF
--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -183,6 +183,13 @@
                 action: 'do-control-focus',
                 data: changeData
             });
+        },
+
+        onCopyControlToConsole: function(changeData) {
+            port.postMessage({
+                action: 'do-copy-control-to-console',
+                data: changeData
+            });
         }
     });
 
@@ -392,6 +399,20 @@
         onSelectionChange: displayFrameData
     });
 
+    var updateControlIdLinks = () => {
+        document.querySelectorAll('.controlId').forEach(element => element.addEventListener('click', function() {
+            const controlId = element.innerText;
+            if (controlId) {
+                const changeData = {
+                    controlId: controlId
+                };
+                port.postMessage({
+                    action: 'do-copy-control-to-console',
+                    data: changeData
+                });
+            }
+        }));
+    };
     // ================================================================================
     // Communication
     // ================================================================================
@@ -511,6 +532,8 @@
 
                 // Close possible open binding info and/or methods info
                 controlBindingsSplitter.hideEndContainer();
+                // Make control ids clickable
+                updateControlIdLinks();
             }
         },
 
@@ -535,6 +558,8 @@
                 document.querySelector('#tab-bindings count').innerHTML = '&nbsp;(' + Object.keys(message.controlBindings).length + ')';
                 // Close possible open binding info and/or methods info
                 controlBindingsSplitterElementsRegistry.hideEndContainer();
+                // Make control ids clickable
+                updateControlIdLinks();
             }
         },
 

--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -387,7 +387,7 @@ var controlProperties = (function () {
         });
         properties[OWN].data = formatedProps;
         properties[OWN].types = types;
-        properties[OWN].options.title = '#' + controlId + ' <span gray>(' + title + ')</span>';
+        properties[OWN].options.title = '#<span class="controlId" title="Click to copy control to console">' + controlId + '</span><span gray>(' + title + ')</span>';
 
         _formatInheritedProperties(controlId, properties);
         _getControlPropertiesAssociations(controlId, properties[OWN]);
@@ -871,7 +871,7 @@ module.exports = {
     getControlActionsFormattedForDataView: function (controlId) {
         return {
             actions: {
-                data: ['Focus', 'Invalidate']
+                data: ['Focus', 'Invalidate', 'Copy to Console']
             },
             own: {
                 options: {

--- a/app/scripts/modules/ui/DataView.js
+++ b/app/scripts/modules/ui/DataView.js
@@ -52,6 +52,13 @@ function DataView(target, options) {
      this.onControlFocused = function (target) {
     };
 
+        /**
+     * Method fired when the Copy to Console button is clicked.
+     * @param {Object} target - arget control to be focused
+     */
+        this.onCopyControlToConsole = function (target) {
+        };
+
     /**
      * Method fired when the Invalidate button is clicked.
      * @param {Object} target - target control to be invalidated
@@ -71,6 +78,7 @@ function DataView(target, options) {
         this.onPropertyUpdated = options.onPropertyUpdated || this.onPropertyUpdated;
         this.onControlInvalidated = options.onControlInvalidated || this.onControlInvalidated;
         this.onControlFocused = options.onControlFocused || this.onControlFocused;
+        this.onCopyControlToConsole = options.onCopyControlToConsole || this.onCopyControlToConsole;
 
         this.onValueClick = options.onValueClick || this.onValueClick;
 
@@ -425,6 +433,7 @@ DataView.prototype._onClickHandler = function () {
             switch (targetElement.id) {
                 case 'control-invalidate' : that._onInvalidateElement(targetElement); break;
                 case 'control-focus' : that._onFocusElement(targetElement); break;
+                case 'control-copy to console' : that._onCopyElementToConsole(targetElement); break;
             }
         }
 
@@ -475,6 +484,15 @@ DataView.prototype._onFocusElement = function (target) {
 
         propertyData.controlId = target.getAttribute('data-control-id');
         that.onControlFocused(propertyData);
+
+};
+
+DataView.prototype._onCopyElementToConsole = function (target) {
+    var that = this;
+    var propertyData = {};
+
+    propertyData.controlId = target.getAttribute('data-control-id');
+    that.onCopyControlToConsole(propertyData);
 
 };
 

--- a/app/styles/less/modules/DataView.less
+++ b/app/styles/less/modules/DataView.less
@@ -93,4 +93,8 @@ data-view {
         padding-left: 5px;
         color: lightcoral;
     }
+
+    .controlId {
+        cursor: pointer;
+    }
 }

--- a/tests/styles/themes/dark/dark.css
+++ b/tests/styles/themes/dark/dark.css
@@ -387,6 +387,9 @@ data-view .disclaimer {
   padding-left: 5px;
   color: lightcoral;
 }
+data-view .controlId {
+  cursor: pointer;
+}
 /* ==========================================================================
    FrameSelect
    ========================================================================== */

--- a/tests/styles/themes/light/light.css
+++ b/tests/styles/themes/light/light.css
@@ -387,6 +387,9 @@ data-view .disclaimer {
   padding-left: 5px;
   color: lightcoral;
 }
+data-view .controlId {
+  cursor: pointer;
+}
 /* ==========================================================================
    FrameSelect
    ========================================================================== */


### PR DESCRIPTION
# Copy Control to Console

_The feature is Inspired by the `Store ... as global variable` feature of the chrome dev. tools debugger._

A click on the id of a control in the `Properties` tab of the `Control Inspector` as well as of the `Elements Registry` or on the button `Copy to console` in the `Action` tab  of the `Control Inspector` will create a global variable starting with 'ui5$' and a number e.g. 'ui5$0' that refers to this control. All control references will be collected in the variable `ui5$temp` for convenience.

The control is not directly assigned to the global variable but wrapped in an object showing the class of the control in the property `isA`. The actual control is in the property `control`. 

<img width="826" alt="image" src="https://user-images.githubusercontent.com/11347561/208958422-04bc7a1a-95ff-495e-a0f7-b326579ed83c.png">

The `savedAs` property is helpful when looking at all collected globals in `ui5$temp`.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/11347561/208960112-914674fa-f3dd-4d43-bda0-381dd5067143.png">

The feature is offered using the following interactions:

* Click on the id of a control in the `Properties` tab of the `Control Inspector`
<img width="701" alt="image" src="https://user-images.githubusercontent.com/11347561/208960558-ffd24214-eca7-4b1b-baee-f78930810060.png">

* Click on the id of a control in the `Properties` tab of the `Elements Registry`
<img width="804" alt="image" src="https://user-images.githubusercontent.com/11347561/208960306-f3863cf7-5098-4585-9572-4ae2942e4d7f.png">

* Click button `Copy to console` in the `Action` tab  of the `Control Inspector`
<img width="763" alt="image" src="https://user-images.githubusercontent.com/11347561/208960681-45dbca9c-5f43-45be-b949-8771784ad7b5.png">

