### PR TITLE
feat: extend copy control to console

### DIFF
--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -51,6 +51,20 @@
     var framesSelect;
     var displayFrameData;
     var updateSupportabilityOverlay;
+    var sharedDataViewOptions = {
+
+        /**
+         * Send message upon click to copy control to console
+         * @param {Object} data
+         */
+        onCopyControlToConsole: function(data) {
+            port.postMessage({
+                action: 'do-copy-control-to-console',
+                data: data,
+                frameId: framesSelect.getSelectedId()
+            });
+        }
+    };
 
     // Main tabbar inside 'UI5' devtools panel
     var UI5TabBar = new TabBar('ui5-tabbar');
@@ -101,7 +115,7 @@
     var controlTreeTabBar = new TabBar('control-tree-tabbar');
 
     // Dataview for control properties
-    var controlProperties = new DataView('control-properties', {
+    var controlProperties = new DataView('control-properties', Object.assign({
 
         /**
          * Send message, that an proprety in the DataView is changed.
@@ -114,7 +128,7 @@
                 frameId: framesSelect.getSelectedId()
             });
         }
-    });
+    }, sharedDataViewOptions));
 
     // Vertical splitter for 'Bindings' tab
     var controlBindingsSplitter = new Splitter('control-bindings-splitter', {
@@ -124,7 +138,7 @@
     });
 
     // Dataview for control aggregations
-    var controlAggregations = new DataView('control-aggregations');
+    var controlAggregations = new DataView('control-aggregations', sharedDataViewOptions);
 
     // Dataview for control binding information
     var controlBindingInfoRightDataView = new DataView('control-bindings-right');
@@ -155,7 +169,7 @@
     });
 
     // Dataview for control events
-    var controlEvents = new DataView('control-events', {
+    var controlEvents = new DataView('control-events', Object.assign ({
 
         /**
          * Method fired when a clickable element is clicked.
@@ -168,9 +182,9 @@
                 frameId: framesSelect.getSelectedId()
             });
         }
-    });
+    }, sharedDataViewOptions));
 
-    var controlActions = new DataView('control-actions', {
+    var controlActions = new DataView('control-actions', Object.assign({
         onControlInvalidated: function (changeData) {
             port.postMessage({
                 action: 'do-control-invalidate',
@@ -183,15 +197,8 @@
                 action: 'do-control-focus',
                 data: changeData
             });
-        },
-
-        onCopyControlToConsole: function(changeData) {
-            port.postMessage({
-                action: 'do-copy-control-to-console',
-                data: changeData
-            });
         }
-    });
+    }, sharedDataViewOptions));
 
     // Bootstrap for 'Control inspector' tab
     // ================================================================================
@@ -267,7 +274,7 @@
     var elementsRegistryTabBar = new TabBar('elements-registry-tabbar');
 
     // Dataview for control properties
-    var controlPropertiesElementsRegistry = new DataView('elements-registry-control-properties', {
+    var controlPropertiesElementsRegistry = new DataView('elements-registry-control-properties', Object.assign({
 
         /**
          * Send message, that an proprety in the DataView is changed.
@@ -280,7 +287,7 @@
                 frameId: framesSelect.getSelectedId()
             });
         }
-    });
+    }, sharedDataViewOptions));
 
     // Vertical splitter for 'Bindings' tab
     var controlBindingsSplitterElementsRegistry = new Splitter('elements-registry-control-bindings-splitter', {
@@ -290,7 +297,7 @@
     });
 
     // Dataview for control aggregations
-    var controlAggregationsElementsRegistry = new DataView('elements-registry-control-aggregations');
+    var controlAggregationsElementsRegistry = new DataView('elements-registry-control-aggregations', sharedDataViewOptions);
 
     // Dataview for control binding information
     var controlBindingInfoRightDataViewElementsRegistry = new DataView('elements-registry-control-bindings-right');
@@ -321,7 +328,7 @@
     });
 
     // Dataview for control events
-    var controlEventsElementsRegistry = new DataView('elements-registry-control-events', {
+    var controlEventsElementsRegistry = new DataView('elements-registry-control-events', Object.assign({
 
         /**
          * Method fired when a clickable element is clicked.
@@ -334,7 +341,7 @@
                 frameId: framesSelect.getSelectedId()
             });
         }
-    });
+    }, sharedDataViewOptions));
 
     displayFrameData = function (options) {
         var frameId = options.selectedId;
@@ -399,20 +406,6 @@
         onSelectionChange: displayFrameData
     });
 
-    var updateControlIdLinks = () => {
-        document.querySelectorAll('.controlId').forEach(element => element.addEventListener('click', function() {
-            const controlId = element.innerText;
-            if (controlId) {
-                const changeData = {
-                    controlId: controlId
-                };
-                port.postMessage({
-                    action: 'do-copy-control-to-console',
-                    data: changeData
-                });
-            }
-        }));
-    };
     // ================================================================================
     // Communication
     // ================================================================================
@@ -532,8 +525,6 @@
 
                 // Close possible open binding info and/or methods info
                 controlBindingsSplitter.hideEndContainer();
-                // Make control ids clickable
-                updateControlIdLinks();
             }
         },
 
@@ -558,8 +549,6 @@
                 document.querySelector('#tab-bindings count').innerHTML = '&nbsp;(' + Object.keys(message.controlBindings).length + ')';
                 // Close possible open binding info and/or methods info
                 controlBindingsSplitterElementsRegistry.hideEndContainer();
-                // Make control ids clickable
-                updateControlIdLinks();
             }
         },
 

--- a/app/scripts/modules/injected/controlUtils.js
+++ b/app/scripts/modules/injected/controlUtils.js
@@ -387,7 +387,7 @@ var controlProperties = (function () {
         });
         properties[OWN].data = formatedProps;
         properties[OWN].types = types;
-        properties[OWN].options.title = '#<span class="controlId" title="Click to copy control to console">' + controlId + '</span><span gray>(' + title + ')</span>';
+        properties[OWN].options.title = '#<span class="controlId" data-control-id="' + controlId + '" title="Click to copy control to console">' + controlId + '</span><span gray>(' + title + ')</span>';
 
         _formatInheritedProperties(controlId, properties);
         _getControlPropertiesAssociations(controlId, properties[OWN]);
@@ -573,7 +573,7 @@ var controlEvents = (function () {
             editableValues: false
         });
         events[OWN].data = evts;
-        events[OWN].options.title = '#' + controlId + ' <span gray>(' + title + ')</span>';
+        events[OWN].options.title = '#<span class="controlId" data-control-id="' + controlId + '" title="Click to copy control to console">' + controlId + '</span><span gray>(' + title + ')</span>';
 
         _formatInheritedEvents(controlId, events);
 
@@ -786,7 +786,7 @@ var controlAggregations = (function () {
             editableValues: false
         });
         aggregations[OWN].data = aggrs;
-        aggregations[OWN].options.title = '#' + controlId + ' <span gray>(' + title + ')</span>';
+        aggregations[OWN].options.title = '#<span class="controlId" data-control-id="' + controlId + '" title="Click to copy control to console">' + controlId + '</span><span gray>(' + title + ')</span>';
 
         _formatInheritedAggregations(controlId, aggregations);
 

--- a/app/scripts/modules/ui/DataView.js
+++ b/app/scripts/modules/ui/DataView.js
@@ -437,6 +437,10 @@ DataView.prototype._onClickHandler = function () {
             }
         }
 
+        if (targetElement.nodeName === 'SPAN' && targetElement.classList.contains('controlId')) {
+            that._onCopyElementToConsole(targetElement);
+        }
+
     };
 };
 

--- a/app/styles/less/modules/DataView.less
+++ b/app/styles/less/modules/DataView.less
@@ -6,18 +6,21 @@ data-view {
     -webkit-transform: translateZ(0);
     word-break: break-all;
 
-    clickable-value {
+    clickable-value,
+    .controlId {
         color: @light-blue;
     }
 
     anchor,
-    clickable-value {
+    clickable-value,
+    .controlId {
         cursor: pointer;
         text-decoration: underline;
     }
 
     anchor:hover,
-    clickable-value:hover {
+    clickable-value:hover,
+    .controlId:hover {
         text-decoration: none;
     }
 
@@ -94,7 +97,4 @@ data-view {
         color: lightcoral;
     }
 
-    .controlId {
-        cursor: pointer;
-    }
 }


### PR DESCRIPTION
--Extend the "copy control to console" functionality to cover all data-view panels that show the control-id in their titles
--Minor refactoring to unify the event handling of all elements that trigger the "copy control to console" action