### PR TITLE
fix: prevent duplicate output

### DIFF
--- a/app/scripts/content/main.js
+++ b/app/scripts/content/main.js
@@ -4,6 +4,22 @@
     var highLighter = require('../modules/content/highLighter.js');
     var port = utils.getPort();
 
+    function confirmScriptInjectionDone() {
+        // Add this action to the Q
+        // This is needed when the devtools are undocked from the current inspected window
+        setTimeout(function () {
+            port.postMessage({
+                action: 'on-main-script-injection'
+            });
+        }, 0);
+    }
+
+    var DONE_FLAG = 'MAIN_SCRIPT_INJECTION_DONE';
+    if (window[DONE_FLAG] === true) {
+        confirmScriptInjectionDone();
+        return;
+    }
+
     // Inject needed scripts into the inspected page
     // ================================================================================
 
@@ -31,13 +47,8 @@
 
     injectScript('vendor/ToolsAPI.js', function () {
         injectScript('scripts/injected/main.js', function () {
-            // Add this action to the Q
-            // This is needed when the devtools are undocked from the current inspected window
-            setTimeout(function () {
-                port.postMessage({
-                    action: 'on-main-script-injection'
-                });
-            }, 0);
+            window[DONE_FLAG] = true;
+            confirmScriptInjectionDone();
         });
     });
 


### PR DESCRIPTION
Fixes duplicate action execution the following scenario:
1. Select a control from the control tree and execute an action e.g. 'copy control to console'
2. Close and reopen the DevTools, while staying on the same page and URL (no navigation)
3. Repeat step 1
Expected: the same result as received for step 1
Actual: the result is displayed twice (e.g. control is copied to the console twice)

On inspection we see that the content script "content/main.js" is injected each time the devTools is reopened.
This happens on request from the script behind the UI5-Inspector tab in DevTools because that script is also
re-executed whenever the DevTools panel is opened and it does not keep any state that persists between the multiple
close and reopen of the panel.

Fixed by adding a flag to the window object that keeps the 'injected' state, so that the initializations inside the content script are not executed more than once.