### PR TITLE
fix: error from popup

### DIFF
--- a/app/scripts/background/main.js
+++ b/app/scripts/background/main.js
@@ -60,14 +60,20 @@
          * @param {Object} message
          */
         'do-script-injection': function (message) {
+            const frameId = message.frameId;
             chrome.windows.getCurrent(w => {
                 chrome.tabs.query({ active: true, windowId: w.id }, tabs => {
+                    const target = {
+                        tabId: tabs[0].id
+                    };
+                    // inject the script only into the frame
+                    // specified in the request from the devTools UI5 panel script;
+                    // If no frameId specified, the script will be injected into the main frame
+                    if (frameId !== undefined) {
+                        target.frameIds = [message.frameId];
+                    }
                     chrome.scripting.executeScript({
-                        target: {
-                            // inject the script only into the frame
-                            // specified in the request from the devTools UI5 panel script
-                            tabId: tabs[0].id, frameIds: [message.frameId]
-                        },
+                        target,
                         files: [message.file]
                     });
                 });


### PR DESCRIPTION
Issue:
Empty popup upon pressing the pageAction, due to error in processing its request to inject content script into the page [that obtains more information about the page]. 
The error is thrown because the request does not contain "frameId", so it passed to chrome.scripting.executeScript a "frameId" with the invalid value of "undefined"

Solution:
The page action should be showing information about the main frame. Given that scripting.executeScript selects the main frame by default, only ensure that no "frameId" with the invalid value of "undefined" is passed to it