### PR TITLE
fix: correct decoding of http response

### DIFF
--- a/app/scripts/modules/utils/multipartmixed2har.js
+++ b/app/scripts/modules/utils/multipartmixed2har.js
@@ -186,14 +186,13 @@ const deMultipart = (content, req, res) => {
          * @param {Object} header
          */
         let resContentType = res.headers.find(header => header.name.toLowerCase() === 'content-type').value;
-        let raw = atob(content);
         let reqBoundary = '--' + req.postData.mimeType.split('boundary=')[1];
         let resBoundary = '--' + resContentType.split('boundary=')[1];
         // jscs:disable
         let requestsRaw = req.postData.text.split(reqBoundary)
             .filter(line => !line.startsWith('--') && line !== '')
             .filter(removeEmptyLinesFilter);
-        let responseRaw = raw.split(resBoundary)
+        let responseRaw = content.split(resBoundary)
             .filter(line => !line.startsWith('--') && line !== '')
             .filter(removeEmptyLinesFilter);
         // jscs:enable
@@ -218,7 +217,10 @@ const getContent = entry =>
          * Gets content of an entry.
          * @param {Object} content
          */
-        entry.getContent(content => resolve(content));
+        entry.getContent((content, encoding) => {
+            const decodedContent = (encoding === 'base64') ? atob(content) : content;
+            resolve(decodedContent);
+        });
     }));
 
 exports.getContent = getContent;


### PR DESCRIPTION
Problem:  "[InvalidCharacterError](https://developer.mozilla.org/en-US/docs/Web/API/Window/atob#invalidcharactererror) "  due to redundant decoding from base64 of a response content that was instead in plain text (no base64 encoding)

Solution: Make use of the second argument to the callback of the native request.getContent function, that signifies if the response is encoded, as documented in the [API reference](https://developer.chrome.com/docs/extensions/reference/api/devtools/network).

Fixes: #272 