### PR TITLE
fix: update repository URL to match new GitHub org/repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SAP/ui5-inspector"
+    "url": "https://github.com/UI5/inspector"
   },
   "scripts": {
     "generate:typescript": "tsc",


### PR DESCRIPTION
The repo moved from SAP/ui5-inspector to UI5/inspector, causing semantic-release to fail with EMISMATCHGITHUBURL during the Release workflow.