### PR TITLE
fix: use correct github-actions[bot] identity in bump-version action

### DIFF
--- a/.github/actions/bump-version/index.js
+++ b/.github/actions/bump-version/index.js
@@ -20,8 +20,8 @@ const run = async () => {
     core.info('Update files version field');
     await exec.exec('node', [path.join(process.env.GITHUB_WORKSPACE, './scripts/update-version.js'), version]);
 
-    await exec.exec('git', ['config', '--global', 'user.name', 'github-actions']);
-    await exec.exec('git', ['config', '--global', 'user.email', 'actions@users.noreply.github.com']);
+    await exec.exec('git', ['config', '--global', 'user.name', 'github-actions[bot]']);
+    await exec.exec('git', ['config', '--global', 'user.email', '41898282+github-actions[bot]@users.noreply.github.com']);
 
     const branch = `bump-version-${version}`;
 


### PR DESCRIPTION
## Summary

- Fix the git identity used by the bump-version GitHub Action to use the correct `github-actions[bot]` Bot account instead of the `actions` Organization account
- This resolves the CLA Assistant blocking all automated release PRs since Feb 2026

## Root Cause

The bump-version action was setting:
```
user.name = 'github-actions'
user.email = 'actions@users.noreply.github.com'
```

This email resolves to the **`actions` Organization** (id: 44036562) on GitHub — not the `github-actions[bot]` Bot. The CLA Assistant's allowlist pattern `*[bot]` checks against the GitHub login, so:
- `"github-actions"` (old) → does NOT match `*[bot]` → **CLA blocked**
- `"github-actions[bot]"` (new) → matches `*[bot]` → **CLA passes**

## Fix

Updated to the correct noreply email format:
```
user.name = 'github-actions[bot]'
user.email = '41898282+github-actions[bot]@users.noreply.github.com'
```

The ID `41898282` is the permanent GitHub database ID for the `github-actions[bot]` account, used by 6,400+ repositories across GitHub.

## Affected PRs

This fix unblocks future release PRs. Previously blocked: #324, #328, #340.

## Test plan

- [x] Verified the CLA Assistant's `checkPatternWildcard()` function matches `"github-actions[bot]"` against `*[bot]` pattern
- [x] Verified via GitHub GraphQL API that `41898282+github-actions[bot]@users.noreply.github.com` resolves to `login: "github-actions[bot]"` (type: Bot)
- [x] All existing tests pass (pre-commit hook ran `grunt test`)
- [ ] After merge: manually trigger Release workflow to verify the next bump-version PR passes CLA