### PR TITLE
feat(elements-registry): highlight control on row hover

### DIFF
--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -284,6 +284,26 @@
                 action: 'do-elements-registry-refresh',
                 frameId: framesSelect.getSelectedId()
             });
+        },
+        /**
+         * Send message to highlight the hovered element on the inspected page.
+         * @param {string} sElementId
+         */
+        onHoverChanged: function (sElementId) {
+            port.postMessage({
+                action: 'on-control-tree-hover',
+                target: sElementId,
+                frameId: framesSelect.getSelectedId()
+            });
+        },
+        /**
+         * Send message to hide the highlight when the mouse leaves the table.
+         */
+        onHoverHide: function () {
+            port.postMessage({
+                action: 'on-hide-highlight',
+                frameId: framesSelect.getSelectedId()
+            });
         }
     });
 

--- a/app/scripts/modules/ui/OElementsRegistryMasterView.js
+++ b/app/scripts/modules/ui/OElementsRegistryMasterView.js
@@ -137,11 +137,22 @@ function OElementsRegistryMasterView(domId, options) {
         this.onRefreshButtonClicked = options.onRefreshButtonClicked || function () {};
     }
 
-        this.oContainerDOM.appendChild(this._createContent());
-        this.oContainerDOM.appendChild(this._createMessage());
+    /**
+     * Fires when the hovered element in the DataGrid changes.
+     * @param {string} sElementId
+     */
+    this.onHoverChanged = (options && options.onHoverChanged) || function (sElementId) {};
 
-        this._setReferences();
-        this._createHandlers();
+    /**
+     * Fires when hover highlight should be hidden.
+     */
+    this.onHoverHide = (options && options.onHoverHide) || function () {};
+
+    this.oContainerDOM.appendChild(this._createContent());
+    this.oContainerDOM.appendChild(this._createMessage());
+
+    this._setReferences();
+    this._createHandlers();
 }
 
 /**
@@ -229,6 +240,8 @@ OElementsRegistryMasterView.prototype._createHandlers = function () {
     this._oFilterContainer.onsearch = this._onSearchEvent.bind(this);
     this._oFilterCheckBox.onchange = this._onOptionsChange.bind(this);
     this._oRefreshButton.onclick = this._onRefresh.bind(this);
+    this.oDataGrid.element.onmouseover = this._onDataGridMouseOver.bind(this);
+    this.oDataGrid.element.onmouseleave = this._onDataGridMouseLeave.bind(this);
 };
 
 /**
@@ -527,6 +540,33 @@ OElementsRegistryMasterView.prototype.selectHandler = function (oEvent) {
     this.XMLDetailView.update(oEvent.data._data);
     this.ControllerDetailView.update(oEvent.data._data.controllerInfo);
     this._sSelectedItem = oEvent.data._data.id;
+};
+
+/**
+ * Event handler for mouseover on the DataGrid element.
+ * Walks up the DOM to find the nearest row with a _dataGridNode and calls onHoverChanged with its element id.
+ * @param {MouseEvent} event
+ * @private
+ */
+OElementsRegistryMasterView.prototype._onDataGridMouseOver = function (event) {
+    let target = event.target;
+
+    while (target && target !== this.oDataGrid.element && !target._dataGridNode) {
+        target = target.parentElement;
+    }
+
+    if (target && target._dataGridNode && target._dataGridNode._data && target._dataGridNode._data.id) {
+        this.onHoverChanged(target._dataGridNode._data.id);
+    }
+};
+
+/**
+ * Event handler for mouseleave on the DataGrid element.
+ * Hides the page highlight when the mouse exits the table.
+ * @private
+ */
+OElementsRegistryMasterView.prototype._onDataGridMouseLeave = function () {
+    this.onHoverHide();
 };
 
 module.exports = OElementsRegistryMasterView;

--- a/tests/modules/ui/OElementsRegistryMasterView.spec.js
+++ b/tests/modules/ui/OElementsRegistryMasterView.spec.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const OElementsRegistryMasterView = require('../../../app/scripts/modules/ui/OElementsRegistryMasterView.js');
+
+describe('OElementsRegistryMasterView', function () {
+    var fixtures = document.getElementById('fixtures');
+    var view;
+
+    beforeEach(function () {
+        fixtures.innerHTML = '<div id="elements-registry-tab-master"></div>';
+
+        // Minimal stubs for required options
+        view = new OElementsRegistryMasterView('elements-registry-tab-master', {
+            XMLDetailView: { update: function () {} },
+            ControllerDetailView: { update: function () {} }
+        });
+    });
+
+    afterEach(function () {
+        fixtures.innerHTML = '';
+    });
+
+    describe('Constructor', function () {
+        it('should have a default no-op onHoverChanged callback', function () {
+            view.onHoverChanged.should.be.a('function');
+            (function () { view.onHoverChanged('someId'); }).should.not.throw();
+        });
+
+        it('should have a default no-op onHoverHide callback', function () {
+            view.onHoverHide.should.be.a('function');
+            (function () { view.onHoverHide(); }).should.not.throw();
+        });
+
+        it('should overwrite onHoverChanged if provided in options', function () {
+            var called = false;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverChanged: function () { called = true; }
+            });
+            v.onHoverChanged('id');
+            called.should.equal(true);
+        });
+
+        it('should overwrite onHoverHide if provided in options', function () {
+            var called = false;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverHide: function () { called = true; }
+            });
+            v.onHoverHide();
+            called.should.equal(true);
+        });
+    });
+
+    describe('_onDataGridMouseOver', function () {
+        it('should call onHoverChanged with the element id when hovering a data row', function () {
+            var hoveredId = null;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverChanged: function (id) { hoveredId = id; }
+            });
+
+            // Simulate a <tr> with a _dataGridNode attached (as DataGrid does)
+            var fakeRow = document.createElement('tr');
+            fakeRow._dataGridNode = { _data: { id: '__button0' } };
+
+            var fakeEvent = { target: fakeRow };
+            v._onDataGridMouseOver(fakeEvent);
+
+            hoveredId.should.equal('__button0');
+        });
+
+        it('should not throw when the target has no _dataGridNode', function () {
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} }
+            });
+
+            var fakeEvent = { target: document.createElement('td') };
+            (function () { v._onDataGridMouseOver(fakeEvent); }).should.not.throw();
+        });
+
+        it('should call onHoverChanged when the event target is a child of the row', function () {
+            var hoveredId = null;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverChanged: function (id) { hoveredId = id; }
+            });
+
+            // Simulate a <td> inside a <tr> — the walk-up path
+            var fakeRow = document.createElement('tr');
+            fakeRow._dataGridNode = { _data: { id: '__button2' } };
+            var fakeCell = document.createElement('td');
+            fakeRow.appendChild(fakeCell);
+
+            var fakeEvent = { target: fakeCell };
+            v._onDataGridMouseOver(fakeEvent);
+
+            hoveredId.should.equal('__button2');
+        });
+
+        it('should not call onHoverChanged when _data.id is empty', function () {
+            var called = false;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverChanged: function () { called = true; }
+            });
+
+            var fakeRow = document.createElement('tr');
+            fakeRow._dataGridNode = { _data: { id: '' } };
+
+            var fakeEvent = { target: fakeRow };
+            v._onDataGridMouseOver(fakeEvent);
+
+            called.should.equal(false);
+        });
+    });
+
+    describe('_onDataGridMouseLeave', function () {
+        it('should call onHoverHide', function () {
+            var hideCalled = false;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverHide: function () { hideCalled = true; }
+            });
+
+            v._onDataGridMouseLeave();
+
+            hideCalled.should.equal(true);
+        });
+    });
+
+    describe('_createHandlers (hover wiring)', function () {
+        it('should wire mouseover on the DataGrid element to _onDataGridMouseOver', function () {
+            var hoveredId = null;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverChanged: function (id) { hoveredId = id; }
+            });
+
+            var fakeRow = document.createElement('tr');
+            fakeRow._dataGridNode = { _data: { id: '__button1' } };
+            v.oDataGrid.element.appendChild(fakeRow);
+
+            var event = new MouseEvent('mouseover', { bubbles: true });
+            fakeRow.dispatchEvent(event);
+
+            hoveredId.should.equal('__button1');
+        });
+
+        it('should wire mouseleave on the DataGrid element to _onDataGridMouseLeave', function () {
+            var hideCalled = false;
+            var v = new OElementsRegistryMasterView('elements-registry-tab-master', {
+                XMLDetailView: { update: function () {} },
+                ControllerDetailView: { update: function () {} },
+                onHoverHide: function () { hideCalled = true; }
+            });
+
+            var event = new MouseEvent('mouseleave', { bubbles: false });
+            v.oDataGrid.element.dispatchEvent(event);
+
+            hideCalled.should.equal(true);
+        });
+    });
+});


### PR DESCRIPTION
Previously, hovering over elements in the Control Tree tab would highlight the corresponding DOM
element on the inspected page, but the Elements Registry tab had no such behavior.

This change adds hover-highlight support to the Elements Registry table by wiring
mouseover/mouseleave handlers on the DataGrid element. When the user hovers a row, the control's
ID is extracted via the DataGrid's internal `_dataGridNode` reference and sent to the content
script using the existing `on-control-tree-hover` message action, which triggers the `highLighter`
to render a blue overlay over the matching DOM element. When the mouse leaves the table,
`on-hide-highlight` is sent to clear the overlay.

The entire highlight infrastructure (`highLighter.ts`, content script message handlers, port
messaging) is reused without modification. The implementation follows the same callback pattern
used by `ControlTree` (`onHoverChanged`/`onHoverHide` options passed at construction time), keeping
the UI component decoupled from the messaging layer.

Guards are in place to skip highlighting when the hovered row has no valid element ID (e.g.
unrendered or anonymous controls), and the DOM walk-up is bounded to the DataGrid container to
avoid traversing into panel chrome on header-row hover.