### PR TITLE
feat(ai): better prompts, console-error context, and idle-session recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ docs/adr/
 docs/agents/
 CONTEXT.md
 prompt.md
+
+# Installed agent skills (managed via `npx skills@latest`)
+.agents/
+.claude/
+agent/
+skills-lock.json

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -467,7 +467,7 @@
             if (frameData[currentFrameId]) {
                 frameData[currentFrameId].consoleErrors = [];
             }
-            // Keep panel cache and page-side buffer in lock-step.
+            // Keep the panel cache and page-side buffer in sync.
             port.postMessage({
                 action: 'do-clear-console-errors',
                 frameId: currentFrameId
@@ -734,7 +734,7 @@
         },
 
         /**
-         * Cache the recent-console-errors snapshot pushed from the injected script.
+         * Cache the console-errors snapshot pushed from the injected script.
          * @param {Object} message
          */
         'on-console-errors-updated': function (message, messageSender) {

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -467,8 +467,7 @@
             if (frameData[currentFrameId]) {
                 frameData[currentFrameId].consoleErrors = [];
             }
-            // Also tell the injected script to clear its live buffer so the panel's cache and
-            // the page-side buffer stay in lock-step.
+            // Keep panel cache and page-side buffer in lock-step.
             port.postMessage({
                 action: 'do-clear-console-errors',
                 frameId: currentFrameId
@@ -735,9 +734,7 @@
         },
 
         /**
-         * Store the recent-console-errors snapshot the injected script pushes on every error
-         * event. The AI Assistant reads this cache via its `getConsoleErrors` seam on each
-         * `sendUserMessage`.
+         * Cache the recent-console-errors snapshot pushed from the injected script.
          * @param {Object} message
          */
         'on-console-errors-updated': function (message, messageSender) {

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -453,6 +453,26 @@
         getAppInfo: function () {
             var currentFrameId = framesSelect.getSelectedId();
             return frameData[currentFrameId] ? frameData[currentFrameId].applicationInformation : null;
+        },
+        getConsoleErrors: function () {
+            var currentFrameId = framesSelect.getSelectedId();
+            return frameData[currentFrameId] && frameData[currentFrameId].consoleErrors ?
+                frameData[currentFrameId].consoleErrors : [];
+        },
+        clearConsoleErrors: function () {
+            var currentFrameId = framesSelect.getSelectedId();
+            if (currentFrameId === undefined || currentFrameId === null) {
+                return;
+            }
+            if (frameData[currentFrameId]) {
+                frameData[currentFrameId].consoleErrors = [];
+            }
+            // Also tell the injected script to clear its live buffer so the panel's cache and
+            // the page-side buffer stay in lock-step.
+            port.postMessage({
+                action: 'do-clear-console-errors',
+                frameId: currentFrameId
+            });
         }
     });
 
@@ -712,6 +732,20 @@
             if (bFrameUpdate) {
                 framesSelect.setData(frameData);
             }
+        },
+
+        /**
+         * Store the recent-console-errors snapshot the injected script pushes on every error
+         * event. The AI Assistant reads this cache via its `getConsoleErrors` seam on each
+         * `sendUserMessage`.
+         * @param {Object} message
+         */
+        'on-console-errors-updated': function (message, messageSender) {
+            var frameId = messageSender.frameId;
+            if (!frameData[frameId]) {
+                return;
+            }
+            frameData[frameId].consoleErrors = message.consoleErrors || [];
         }
     };
 

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -467,7 +467,8 @@
             if (frameData[currentFrameId]) {
                 frameData[currentFrameId].consoleErrors = [];
             }
-            // Keep the panel cache and page-side buffer in sync.
+            // Also tell the injected script to clear its live buffer so the panel's cache and
+            // the page-side buffer stay in lock-step.
             port.postMessage({
                 action: 'do-clear-console-errors',
                 frameId: currentFrameId
@@ -734,7 +735,9 @@
         },
 
         /**
-         * Cache the console-errors snapshot pushed from the injected script.
+         * Store the recent-console-errors snapshot the injected script pushes on every error
+         * event. The AI Assistant reads this cache via its `getConsoleErrors` seam on each
+         * `sendUserMessage`.
          * @param {Object} message
          */
         'on-console-errors-updated': function (message, messageSender) {

--- a/app/scripts/devtools/panel/ui5/main.js
+++ b/app/scripts/devtools/panel/ui5/main.js
@@ -467,8 +467,7 @@
             if (frameData[currentFrameId]) {
                 frameData[currentFrameId].consoleErrors = [];
             }
-            // Also tell the injected script to clear its live buffer so the panel's cache and
-            // the page-side buffer stay in lock-step.
+            // Keep the panel cache and page-side buffer in sync.
             port.postMessage({
                 action: 'do-clear-console-errors',
                 frameId: currentFrameId
@@ -735,9 +734,7 @@
         },
 
         /**
-         * Store the recent-console-errors snapshot the injected script pushes on every error
-         * event. The AI Assistant reads this cache via its `getConsoleErrors` seam on each
-         * `sendUserMessage`.
+         * Cache the console-errors snapshot pushed from the injected script.
          * @param {Object} message
          */
         'on-console-errors-updated': function (message, messageSender) {

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -17,11 +17,8 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     // Create global reference for the extension.
     ui5inspector.createReferences();
 
-    // Install the recent-console-errors capture. The buffer feeds the AI Assistant's per-turn
-    // Recent Console Errors section — a bounded FIFO of the three most-recent, deduplicated
-    // console errors and warnings from the inspected page. The `onRecord` callback pushes the
-    // current snapshot to the panel on every event so the panel-side cache stays fresh; the
-    // AssistantController's `getConsoleErrors` seam then reads from that cache per send.
+    // Capture console errors. `onRecord` pushes a snapshot to the panel on every event so its
+    // cache stays in sync with the page-side buffer.
     var consoleErrorHandle = consoleErrorCapture.install(window, {
         onRecord: function () {
             message.send({
@@ -383,7 +380,7 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
         },
 
         /**
-         * Clear the recent-console-errors buffer. Invoked by the panel's Clear Conversation flow.
+         * Clear the console-errors buffer. Called from the panel's Clear Conversation flow.
          */
         'do-clear-console-errors': function () {
             consoleErrorHandle.buffer.clear();

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -17,8 +17,11 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     // Create global reference for the extension.
     ui5inspector.createReferences();
 
-    // Capture console errors. `onRecord` pushes a snapshot to the panel on every event so its
-    // cache stays in sync with the page-side buffer.
+    // Install the recent-console-errors capture. The buffer feeds the AI Assistant's per-turn
+    // Recent Console Errors section — a bounded FIFO of the three most-recent, deduplicated
+    // console errors and warnings from the inspected page. The `onRecord` callback pushes the
+    // current snapshot to the panel on every event so the panel-side cache stays fresh; the
+    // AssistantController's `getConsoleErrors` seam then reads from that cache per send.
     var consoleErrorHandle = consoleErrorCapture.install(window, {
         onRecord: function () {
             message.send({
@@ -380,7 +383,7 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
         },
 
         /**
-         * Clear the console-errors buffer. Called from the panel's Clear Conversation flow.
+         * Clear the recent-console-errors buffer. Invoked by the panel's Clear Conversation flow.
          */
         'do-clear-console-errors': function () {
             consoleErrorHandle.buffer.clear();

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -6,6 +6,7 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     var controlUtils = require('../modules/injected/controlUtils.js');
     var rightClickHandler = require('../modules/injected/rightClickHandler.js');
     var applicationUtils = require('../modules/injected/applicationUtils');
+    var consoleErrorCapture = require('../modules/injected/consoleErrorCapture.js');
 
     var ui5TempName = 'ui5$temp';
 	var ui5Temp = window[ui5TempName] = {}; // Container for all temp. variables
@@ -15,6 +16,20 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
 
     // Create global reference for the extension.
     ui5inspector.createReferences();
+
+    // Install the recent-console-errors capture. The buffer feeds the AI Assistant's per-turn
+    // Recent Console Errors section — a bounded FIFO of the three most-recent, deduplicated
+    // console errors and warnings from the inspected page. The `onRecord` callback pushes the
+    // current snapshot to the panel on every event so the panel-side cache stays fresh; the
+    // AssistantController's `getConsoleErrors` seam then reads from that cache per send.
+    var consoleErrorHandle = consoleErrorCapture.install(window, {
+        onRecord: function () {
+            message.send({
+                action: 'on-console-errors-updated',
+                consoleErrors: consoleErrorHandle.buffer.snapshot()
+            });
+        }
+    });
 
     /**
      * Mutation observer for DOM elements
@@ -365,6 +380,17 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
             } else {
                 log(`No Control with id ${sControlId} exists`);
             }
+        },
+
+        /**
+         * Clear the recent-console-errors buffer. Invoked by the panel's Clear Conversation flow.
+         */
+        'do-clear-console-errors': function () {
+            consoleErrorHandle.buffer.clear();
+            message.send({
+                action: 'on-console-errors-updated',
+                consoleErrors: []
+            });
         }
     };
 

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -17,8 +17,8 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     // Create global reference for the extension.
     ui5inspector.createReferences();
 
-    // Install the recent-console-errors capture. `onRecord` pushes a fresh snapshot to the
-    // panel so its cache stays in sync with the page-side buffer.
+    // Capture console errors. `onRecord` pushes a snapshot to the panel on every event so its
+    // cache stays in sync with the page-side buffer.
     var consoleErrorHandle = consoleErrorCapture.install(window, {
         onRecord: function () {
             message.send({
@@ -380,7 +380,7 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
         },
 
         /**
-         * Clear the recent-console-errors buffer. Invoked by the panel's Clear Conversation flow.
+         * Clear the console-errors buffer. Called from the panel's Clear Conversation flow.
          */
         'do-clear-console-errors': function () {
             consoleErrorHandle.buffer.clear();

--- a/app/scripts/injected/main.js
+++ b/app/scripts/injected/main.js
@@ -17,11 +17,8 @@ sap.ui.require(['ToolsAPI'], function (ToolsAPI) {
     // Create global reference for the extension.
     ui5inspector.createReferences();
 
-    // Install the recent-console-errors capture. The buffer feeds the AI Assistant's per-turn
-    // Recent Console Errors section — a bounded FIFO of the three most-recent, deduplicated
-    // console errors and warnings from the inspected page. The `onRecord` callback pushes the
-    // current snapshot to the panel on every event so the panel-side cache stays fresh; the
-    // AssistantController's `getConsoleErrors` seam then reads from that cache per send.
+    // Install the recent-console-errors capture. `onRecord` pushes a fresh snapshot to the
+    // panel so its cache stays in sync with the page-side buffer.
     var consoleErrorHandle = consoleErrorCapture.install(window, {
         onRecord: function () {
             message.send({

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -13,10 +13,12 @@ const ConversationStore = require('./ConversationStore.js');
  * @param {PromptClient} [options.promptClient]
  * @param {ConversationStore} [options.conversationStore]
  * @param {Function} [options.getAppInfo] - Returns the app metadata snapshot for session seeding.
- * @param {Function} [options.getConsoleErrors] - Returns the recent-console-errors snapshot;
- *     passed to {@link PromptBuilder#buildUserPrompt} on each send.
- * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer.
- *     Called from {@link #clearConversation} and {@link #setUrl} so both signals reset together.
+ * @param {Function} [options.getConsoleErrors] - Returns the current recent-console-errors snapshot.
+ *     Called once per {@link #sendUserMessage}; its result is forwarded to
+ *     {@link PromptBuilder#buildUserPrompt} as the third argument.
+ * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer for the
+ *     current URL. Invoked from {@link #clearConversation} and {@link #setUrl} so a "start fresh"
+ *     trigger resets both signals in lock-step.
  * @constructor
  */
 function AssistantController({
@@ -160,8 +162,9 @@ AssistantController.prototype._seedSession = function () {
 };
 
 /**
- * Call the injected `getConsoleErrors`. A missing or throwing accessor returns [] so a broken
- * wiring doesn't break the send.
+ * Invoke the injected `getConsoleErrors` accessor and coerce the result into an array. A missing
+ * or throwing accessor collapses to an empty array so a broken panel-side wiring never breaks the
+ * send flow — the Prompt Builder simply omits the section.
  * @private
  * @returns {Array}
  */
@@ -279,7 +282,8 @@ AssistantController.prototype.setUrl = function (url) {
         this._emit('inspection-context-cleared');
     }
 
-    // Buffered errors belong to the old page.
+    // The buffered errors belong to the previously inspected page. Reset alongside Inspection
+    // Context and Conversation Memory so a new debugging session starts truly fresh.
     this._safeClearConsoleErrors();
 
     if (this._capabilityState.status !== 'ready') {
@@ -316,8 +320,10 @@ AssistantController.prototype.updateInspectionContext = function (context) {
 };
 
 /**
- * Clear conversation memory, destroy the session, and reseed. Also clears the console-errors
- * buffer so both reset together. Re-emits `ready` so the view refreshes the token counter.
+ * Clear conversation memory, destroy the session, and reseed. Also clears the recent-console-errors
+ * buffer for the current URL so "start fresh" resets both signals in lock-step. Re-emits `ready` so
+ * the view can refresh the token counter — otherwise it keeps the pre-clear usage over a fresh
+ * session.
  *
  * @returns {Promise<void>}
  */
@@ -333,13 +339,15 @@ AssistantController.prototype.clearConversation = function () {
 };
 
 /**
+ * Invoke the injected `clearConsoleErrors` callback. Swallows exceptions so a broken panel-side
+ * wiring never blocks the clear flow.
  * @private
  */
 AssistantController.prototype._safeClearConsoleErrors = function () {
     try {
         this._clearConsoleErrors();
     } catch (e) {
-        // See _safeGetConsoleErrors.
+        // Intentionally swallowed. See _safeGetConsoleErrors for the same rationale.
     }
 };
 

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -53,9 +53,6 @@ function AssistantController({
  * Events: `capability-state-changed`, `conversation-loaded`, `stream-chunk`, `stream-complete`,
  * `stream-failed`, `conversation-cleared`, `inspection-context-cleared`.
  *
- * In-process event bus, not `chrome.runtime` message dispatch. The cross-process port protocol
- * lives in PromptClient.
- *
  * @param {string} event
  * @param {Function} handler
  */
@@ -188,10 +185,8 @@ AssistantController.prototype.sendUserMessage = function (userMessage) {
 
     this._isStreaming = true;
 
-    // Wait for any in-flight reseed so a Send during the destroy-then-reseed window does not race
-    // the Prompt Client's "No active session" guard. If the reseed rejects, reject the send with
-    // the same error and leave `session-failed` in place — do not overwrite it with
-    // `streaming-failed`.
+    // Wait for any in-flight reseed so a Send during the destroy-then-reseed window does not
+    // race the Prompt Client's "No active session" guard.
     return this._pendingReseed.then(() => {
         return this._promptClient.promptStreaming(formatted).then((stream) => {
             return this._consumeStream(stream);
@@ -294,15 +289,9 @@ AssistantController.prototype.setUrl = function (url) {
 };
 
 /**
- * Set the Inspection Context for subsequent prompts. It is sticky — reused on every
- * `sendUserMessage` until:
- *   1. A different snapshot replaces it (`updateInspectionContext(ctx2)`).
- *   2. The developer detaches it (`updateInspectionContext(null)`).
- *   3. The inspected page navigates (`setUrl(differentUrl)`).
- *
- * `updateInspectionContext(null)` emits `inspection-context-cleared` if a snapshot was attached;
- * replacement does not. Never persisted. Clearing Conversation Memory is orthogonal —
- * see `clearConversation`.
+ * Set the Inspection Context for subsequent prompts. Sticky — reused on every `sendUserMessage`
+ * until replaced, cleared with `null`, or dropped by `setUrl`. Clearing with `null` emits
+ * `inspection-context-cleared`; replacement does not. Never persisted.
  *
  * @param {Object} [context] - Inspection context with optional `control` snapshot.
  */

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -41,10 +41,10 @@ function AssistantController({
     this._conversationMemory = [];
     this._inspectionContext = null;
     this._isStreaming = false;
-    // The in-flight reseed. `sendUserMessage` awaits this so a Send during a reseed window does
-    // not race the Prompt Client's "No active session" guard. A reseed rejection is caught by
-    // `_trackReseed` and surfaced as `session-failed`.
-    this._pendingReseed = Promise.resolve();
+    // The in-flight reseed, or `null` when no reseed is running. `sendUserMessage` awaits this
+    // so a Send during a reseed window does not race the Prompt Client's "No active session"
+    // guard. A reseed rejection is caught by `_trackReseed` and surfaced as `session-failed`.
+    this._pendingReseed = null;
 }
 
 /**
@@ -118,6 +118,9 @@ AssistantController.prototype.initialize = function () {
  * translate a failure into `session-failed`. With `announceReady`, re-emit `ready` on success so
  * the view can refresh session-tied state (token counter, quota styling, input enablement).
  *
+ * `_pendingReseed` is cleared back to `null` when the reseed settles so the idle-recovery check
+ * in `sendUserMessage` has a single source of truth for "no reseed in flight".
+ *
  * @private
  * @param {Promise<*>} rawSeed
  * @param {{announceReady?: boolean}} [options]
@@ -126,10 +129,12 @@ AssistantController.prototype.initialize = function () {
 AssistantController.prototype._trackReseed = function (rawSeed, { announceReady = false } = {}) {
     this._pendingReseed = rawSeed;
     return rawSeed.then(() => {
+        this._pendingReseed = null;
         if (announceReady && this._capabilityState.status === 'ready') {
             this._setCapabilityState('ready', 'Gemini Nano is ready', 0);
         }
     }, (err) => {
+        this._pendingReseed = null;
         this._setCapabilityState('session-failed', err && err.message ? err.message : 'Session creation failed', 0);
     });
 };
@@ -174,9 +179,21 @@ AssistantController.prototype.sendUserMessage = function (userMessage) {
 
     this._isStreaming = true;
 
-    // Wait for any in-flight reseed so a Send during the destroy-then-reseed window does not
-    // race the Prompt Client's "No active session" guard.
-    return this._pendingReseed.then(() => {
+    // Idle recovery: Chrome may have killed the extension's background service worker while
+    // the panel was idle, tearing down the Prompt API session without the controller knowing.
+    // If no reseed is already in flight, kick one off so the Send transparently reseeds
+    // instead of tripping the Prompt Client's "No active session" guard. If another reseed
+    // origin (setUrl/clearConversation/downloadModel) is already running, `_pendingReseed`
+    // is non-null and the Send simply awaits the existing reseed — same invariant as before.
+    if (!this._promptClient.hasActiveSession() && this._pendingReseed === null) {
+        this._trackReseed(this._seedSession());
+    }
+
+    // Await any in-flight reseed (idle-recovery just above, or an earlier
+    // setUrl/clearConversation/downloadModel) so a Send during a reseed window does not race
+    // the Prompt Client's "No active session" guard. Falls through to a resolved sentinel
+    // when nothing is pending.
+    return (this._pendingReseed || Promise.resolve()).then(() => {
         return this._promptClient.promptStreaming(formatted).then((stream) => {
             return this._consumeStream(stream);
         }).then((fullText) => {

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -114,34 +114,23 @@ AssistantController.prototype.initialize = function () {
 };
 
 /**
- * Store `rawSeed` as `_pendingReseed` (raw, so `sendUserMessage` awaiters observe rejection) and
- * translate a failure into `session-failed`.
+ * Store `rawSeed` as `_pendingReseed` (so `sendUserMessage` awaiters observe rejection) and
+ * translate a failure into `session-failed`. With `announceReady`, re-emit `ready` on success so
+ * the view can refresh session-tied state (token counter, quota styling, input enablement).
  *
  * @private
  * @param {Promise<*>} rawSeed
+ * @param {{announceReady?: boolean}} [options]
  * @returns {Promise<void>}
  */
-AssistantController.prototype._trackReseed = function (rawSeed) {
+AssistantController.prototype._trackReseed = function (rawSeed, { announceReady = false } = {}) {
     this._pendingReseed = rawSeed;
-    return rawSeed.then(undefined, (err) => {
-        this._setCapabilityState('session-failed', err && err.message ? err.message : 'Session creation failed', 0);
-    });
-};
-
-/**
- * Like `_trackReseed`, but re-emits `ready` on success so the view can refresh session-tied state
- * (token counter, quota styling, input enablement). Used by destroy-then-reseed paths. On failure,
- * does not emit `ready` — `session-failed` is already surfaced.
- *
- * @private
- * @param {Promise<*>} rawSeed
- * @returns {Promise<void>}
- */
-AssistantController.prototype._trackReseedAndAnnounceReady = function (rawSeed) {
-    return this._trackReseed(rawSeed).then(() => {
-        if (this._capabilityState.status === 'ready') {
+    return rawSeed.then(() => {
+        if (announceReady && this._capabilityState.status === 'ready') {
             this._setCapabilityState('ready', 'Gemini Nano is ready', 0);
         }
+    }, (err) => {
+        this._setCapabilityState('session-failed', err && err.message ? err.message : 'Session creation failed', 0);
     });
 };
 
@@ -285,7 +274,7 @@ AssistantController.prototype.setUrl = function (url) {
         this._promptClient.destroy();
         return this._seedSession();
     });
-    return this._trackReseedAndAnnounceReady(rawSeed);
+    return this._trackReseed(rawSeed, { announceReady: true });
 };
 
 /**
@@ -318,7 +307,7 @@ AssistantController.prototype.clearConversation = function () {
         this._emit('conversation-cleared');
         return this._seedSession();
     });
-    return this._trackReseedAndAnnounceReady(rawSeed);
+    return this._trackReseed(rawSeed, { announceReady: true });
 };
 
 /**

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -13,12 +13,10 @@ const ConversationStore = require('./ConversationStore.js');
  * @param {PromptClient} [options.promptClient]
  * @param {ConversationStore} [options.conversationStore]
  * @param {Function} [options.getAppInfo] - Returns the app metadata snapshot for session seeding.
- * @param {Function} [options.getConsoleErrors] - Returns the current recent-console-errors snapshot.
- *     Called once per {@link #sendUserMessage}; its result is forwarded to
- *     {@link PromptBuilder#buildUserPrompt} as the third argument.
- * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer for the
- *     current URL. Invoked from {@link #clearConversation} and {@link #setUrl} so a "start fresh"
- *     trigger resets both signals in lock-step.
+ * @param {Function} [options.getConsoleErrors] - Returns the recent-console-errors snapshot;
+ *     forwarded to {@link PromptBuilder#buildUserPrompt} on each send.
+ * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer.
+ *     Invoked from {@link #clearConversation} and {@link #setUrl} so both signals reset in lock-step.
  * @constructor
  */
 function AssistantController({
@@ -162,9 +160,8 @@ AssistantController.prototype._seedSession = function () {
 };
 
 /**
- * Invoke the injected `getConsoleErrors` accessor and coerce the result into an array. A missing
- * or throwing accessor collapses to an empty array so a broken panel-side wiring never breaks the
- * send flow — the Prompt Builder simply omits the section.
+ * Invoke the injected `getConsoleErrors` accessor. Missing/throwing accessor collapses to
+ * an empty array so a broken wiring never breaks the send flow.
  * @private
  * @returns {Array}
  */
@@ -282,8 +279,7 @@ AssistantController.prototype.setUrl = function (url) {
         this._emit('inspection-context-cleared');
     }
 
-    // The buffered errors belong to the previously inspected page. Reset alongside Inspection
-    // Context and Conversation Memory so a new debugging session starts truly fresh.
+    // The buffered errors belong to the previously inspected page.
     this._safeClearConsoleErrors();
 
     if (this._capabilityState.status !== 'ready') {
@@ -339,15 +335,13 @@ AssistantController.prototype.clearConversation = function () {
 };
 
 /**
- * Invoke the injected `clearConsoleErrors` callback. Swallows exceptions so a broken panel-side
- * wiring never blocks the clear flow.
  * @private
  */
 AssistantController.prototype._safeClearConsoleErrors = function () {
     try {
         this._clearConsoleErrors();
     } catch (e) {
-        // Intentionally swallowed. See _safeGetConsoleErrors for the same rationale.
+        // See _safeGetConsoleErrors.
     }
 };
 

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -14,9 +14,9 @@ const ConversationStore = require('./ConversationStore.js');
  * @param {ConversationStore} [options.conversationStore]
  * @param {Function} [options.getAppInfo] - Returns the app metadata snapshot for session seeding.
  * @param {Function} [options.getConsoleErrors] - Returns the recent-console-errors snapshot;
- *     forwarded to {@link PromptBuilder#buildUserPrompt} on each send.
+ *     passed to {@link PromptBuilder#buildUserPrompt} on each send.
  * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer.
- *     Invoked from {@link #clearConversation} and {@link #setUrl} so both signals reset in lock-step.
+ *     Called from {@link #clearConversation} and {@link #setUrl} so both signals reset together.
  * @constructor
  */
 function AssistantController({
@@ -160,8 +160,8 @@ AssistantController.prototype._seedSession = function () {
 };
 
 /**
- * Invoke the injected `getConsoleErrors` accessor. Missing/throwing accessor collapses to
- * an empty array so a broken wiring never breaks the send flow.
+ * Call the injected `getConsoleErrors`. A missing or throwing accessor returns [] so a broken
+ * wiring doesn't break the send.
  * @private
  * @returns {Array}
  */
@@ -279,7 +279,7 @@ AssistantController.prototype.setUrl = function (url) {
         this._emit('inspection-context-cleared');
     }
 
-    // The buffered errors belong to the previously inspected page.
+    // Buffered errors belong to the old page.
     this._safeClearConsoleErrors();
 
     if (this._capabilityState.status !== 'ready') {
@@ -316,10 +316,8 @@ AssistantController.prototype.updateInspectionContext = function (context) {
 };
 
 /**
- * Clear conversation memory, destroy the session, and reseed. Also clears the recent-console-errors
- * buffer for the current URL so "start fresh" resets both signals in lock-step. Re-emits `ready` so
- * the view can refresh the token counter — otherwise it keeps the pre-clear usage over a fresh
- * session.
+ * Clear conversation memory, destroy the session, and reseed. Also clears the console-errors
+ * buffer so both reset together. Re-emits `ready` so the view refreshes the token counter.
  *
  * @returns {Promise<void>}
  */

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -13,12 +13,10 @@ const ConversationStore = require('./ConversationStore.js');
  * @param {PromptClient} [options.promptClient]
  * @param {ConversationStore} [options.conversationStore]
  * @param {Function} [options.getAppInfo] - Returns the app metadata snapshot for session seeding.
- * @param {Function} [options.getConsoleErrors] - Returns the current recent-console-errors snapshot.
- *     Called once per {@link #sendUserMessage}; its result is forwarded to
- *     {@link PromptBuilder#buildUserPrompt} as the third argument.
- * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer for the
- *     current URL. Invoked from {@link #clearConversation} and {@link #setUrl} so a "start fresh"
- *     trigger resets both signals in lock-step.
+ * @param {Function} [options.getConsoleErrors] - Returns the recent-console-errors snapshot;
+ *     passed to {@link PromptBuilder#buildUserPrompt} on each send.
+ * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer.
+ *     Called from {@link #clearConversation} and {@link #setUrl} so both signals reset together.
  * @constructor
  */
 function AssistantController({
@@ -162,9 +160,8 @@ AssistantController.prototype._seedSession = function () {
 };
 
 /**
- * Invoke the injected `getConsoleErrors` accessor and coerce the result into an array. A missing
- * or throwing accessor collapses to an empty array so a broken panel-side wiring never breaks the
- * send flow — the Prompt Builder simply omits the section.
+ * Call the injected `getConsoleErrors`. A missing or throwing accessor returns [] so a broken
+ * wiring doesn't break the send.
  * @private
  * @returns {Array}
  */
@@ -282,8 +279,7 @@ AssistantController.prototype.setUrl = function (url) {
         this._emit('inspection-context-cleared');
     }
 
-    // The buffered errors belong to the previously inspected page. Reset alongside Inspection
-    // Context and Conversation Memory so a new debugging session starts truly fresh.
+    // Buffered errors belong to the old page.
     this._safeClearConsoleErrors();
 
     if (this._capabilityState.status !== 'ready') {
@@ -320,10 +316,8 @@ AssistantController.prototype.updateInspectionContext = function (context) {
 };
 
 /**
- * Clear conversation memory, destroy the session, and reseed. Also clears the recent-console-errors
- * buffer for the current URL so "start fresh" resets both signals in lock-step. Re-emits `ready` so
- * the view can refresh the token counter — otherwise it keeps the pre-clear usage over a fresh
- * session.
+ * Clear conversation memory, destroy the session, and reseed. Also clears the console-errors
+ * buffer so both reset together. Re-emits `ready` so the view refreshes the token counter.
  *
  * @returns {Promise<void>}
  */
@@ -339,15 +333,13 @@ AssistantController.prototype.clearConversation = function () {
 };
 
 /**
- * Invoke the injected `clearConsoleErrors` callback. Swallows exceptions so a broken panel-side
- * wiring never blocks the clear flow.
  * @private
  */
 AssistantController.prototype._safeClearConsoleErrors = function () {
     try {
         this._clearConsoleErrors();
     } catch (e) {
-        // Intentionally swallowed. See _safeGetConsoleErrors for the same rationale.
+        // See _safeGetConsoleErrors.
     }
 };
 

--- a/app/scripts/modules/ai/AssistantController.js
+++ b/app/scripts/modules/ai/AssistantController.js
@@ -13,18 +13,28 @@ const ConversationStore = require('./ConversationStore.js');
  * @param {PromptClient} [options.promptClient]
  * @param {ConversationStore} [options.conversationStore]
  * @param {Function} [options.getAppInfo] - Returns the app metadata snapshot for session seeding.
+ * @param {Function} [options.getConsoleErrors] - Returns the current recent-console-errors snapshot.
+ *     Called once per {@link #sendUserMessage}; its result is forwarded to
+ *     {@link PromptBuilder#buildUserPrompt} as the third argument.
+ * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer for the
+ *     current URL. Invoked from {@link #clearConversation} and {@link #setUrl} so a "start fresh"
+ *     trigger resets both signals in lock-step.
  * @constructor
  */
 function AssistantController({
     promptBuilder = new PromptBuilder(),
     promptClient = new PromptClient(),
     conversationStore = new ConversationStore(),
-    getAppInfo = () => null
+    getAppInfo = () => null,
+    getConsoleErrors = () => [],
+    clearConsoleErrors = () => {}
 } = {}) {
     this._promptBuilder = promptBuilder;
     this._promptClient = promptClient;
     this._conversationStore = conversationStore;
     this._getAppInfo = getAppInfo;
+    this._getConsoleErrors = getConsoleErrors;
+    this._clearConsoleErrors = clearConsoleErrors;
 
     // Seeded as `unavailable` until `initialize()` resolves the real status.
     this._capabilityState = { status: 'unavailable', message: 'Checking model status...', progress: 0 };
@@ -152,6 +162,22 @@ AssistantController.prototype._seedSession = function () {
 };
 
 /**
+ * Invoke the injected `getConsoleErrors` accessor and coerce the result into an array. A missing
+ * or throwing accessor collapses to an empty array so a broken panel-side wiring never breaks the
+ * send flow — the Prompt Builder simply omits the section.
+ * @private
+ * @returns {Array}
+ */
+AssistantController.prototype._safeGetConsoleErrors = function () {
+    try {
+        const snapshot = this._getConsoleErrors();
+        return Array.isArray(snapshot) ? snapshot : [];
+    } catch (e) {
+        return [];
+    }
+};
+
+/**
  * Send a user message: build the prompt, stream the response, persist both turns, and emit stream
  * events. The current Inspection Context is injected — see `updateInspectionContext` for its
  * lifecycle.
@@ -160,7 +186,8 @@ AssistantController.prototype._seedSession = function () {
  * @returns {Promise<{content: string}>}
  */
 AssistantController.prototype.sendUserMessage = function (userMessage) {
-    const formatted = this._promptBuilder.buildUserPrompt(userMessage, this._inspectionContext);
+    const consoleErrors = this._safeGetConsoleErrors();
+    const formatted = this._promptBuilder.buildUserPrompt(userMessage, this._inspectionContext, consoleErrors);
 
     this._isStreaming = true;
 
@@ -255,6 +282,10 @@ AssistantController.prototype.setUrl = function (url) {
         this._emit('inspection-context-cleared');
     }
 
+    // The buffered errors belong to the previously inspected page. Reset alongside Inspection
+    // Context and Conversation Memory so a new debugging session starts truly fresh.
+    this._safeClearConsoleErrors();
+
     if (this._capabilityState.status !== 'ready') {
         return Promise.resolve();
     }
@@ -289,19 +320,35 @@ AssistantController.prototype.updateInspectionContext = function (context) {
 };
 
 /**
- * Clear conversation memory, destroy the session, and reseed. Re-emits `ready` so the view can
- * refresh the token counter — otherwise it keeps the pre-clear usage over a fresh session.
+ * Clear conversation memory, destroy the session, and reseed. Also clears the recent-console-errors
+ * buffer for the current URL so "start fresh" resets both signals in lock-step. Re-emits `ready` so
+ * the view can refresh the token counter — otherwise it keeps the pre-clear usage over a fresh
+ * session.
  *
  * @returns {Promise<void>}
  */
 AssistantController.prototype.clearConversation = function () {
     const rawSeed = this._conversationStore.clear(this._currentUrl).then(() => {
         this._conversationMemory = [];
+        this._safeClearConsoleErrors();
         this._promptClient.destroy();
         this._emit('conversation-cleared');
         return this._seedSession();
     });
     return this._trackReseedAndAnnounceReady(rawSeed);
+};
+
+/**
+ * Invoke the injected `clearConsoleErrors` callback. Swallows exceptions so a broken panel-side
+ * wiring never blocks the clear flow.
+ * @private
+ */
+AssistantController.prototype._safeClearConsoleErrors = function () {
+    try {
+        this._clearConsoleErrors();
+    } catch (e) {
+        // Intentionally swallowed. See _safeGetConsoleErrors for the same rationale.
+    }
 };
 
 /**

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -3,18 +3,18 @@
 // Per-section safety-net caps. The shape-driven curation below is the primary volume control;
 // these caps only trigger on adversarial inputs (a control with 500 properties, a runaway
 // aggregation, etc.). Truncation appends `... [truncated]` so the model sees the boundary.
-var PROPERTIES_CAP = 800;
-var BINDINGS_CAP = 800;
-var AGGREGATIONS_CAP = 400;
+const PROPERTIES_CAP = 800;
+const BINDINGS_CAP = 800;
+const AGGREGATIONS_CAP = 400;
 
 // Bindings render their resolved values inline, so a single overlarge value cannot burn the
 // whole bindings-section budget on its own.
-var BINDING_VALUE_CAP = 100;
+const BINDING_VALUE_CAP = 100;
 
 // Placeholder for adversarial input that cannot be JSON-serialized (e.g. a circular graph).
 // Kept identical to the string the previous JSON-dump implementation emitted, so log-grep
 // muscle memory keeps working.
-var UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
+const UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
 
 /**
  * Stringify an arbitrary value for a prompt line. Objects go through JSON.stringify so we
@@ -49,7 +49,7 @@ function _stringifyValue(value) {
  * @returns {string}
  */
 function _stringifyBindingValue(value) {
-    var rendered = _stringifyValue(value);
+    const rendered = _stringifyValue(value);
     if (rendered.length > BINDING_VALUE_CAP) {
         return rendered.substring(0, BINDING_VALUE_CAP) + '...';
     }
@@ -71,10 +71,10 @@ function _renderAggregationLine(name, children) {
         return '- ' + name + ': empty';
     }
 
-    var count = children.length;
+    const count = children.length;
 
     if (count <= 3) {
-        var ids = children.map(function (child) {
+        const ids = children.map(function (child) {
             return (child && child.id) || '?';
         });
         return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
@@ -83,17 +83,17 @@ function _renderAggregationLine(name, children) {
     // Type histogram, insertion order preserved so the model sees the "dominant" type first
     // if children were listed in that order (they typically are — a Page's `content` is a
     // Text-heavy list, then a Button tail).
-    var histogram = Object.create(null);
-    var order = [];
-    for (var i = 0; i < children.length; i++) {
-        var type = (children[i] && children[i].type) || '?';
+    const histogram = Object.create(null);
+    const order = [];
+    for (let i = 0; i < children.length; i++) {
+        const type = (children[i] && children[i].type) || '?';
         if (!Object.prototype.hasOwnProperty.call(histogram, type)) {
             histogram[type] = 0;
             order.push(type);
         }
         histogram[type] += 1;
     }
-    var parts = order.map(function (type) {
+    const parts = order.map(function (type) {
         return type + ' × ' + histogram[type];
     });
 

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Safety-net caps against adversarial inputs. Truncation appends `... [truncated]`.
+// Per-section size caps. Truncation appends `... [truncated]`.
 const PROPERTIES_CAP = 800;
 const BINDINGS_CAP = 800;
 const AGGREGATIONS_CAP = 400;
@@ -65,7 +65,7 @@ function _renderAggregationLine(name, children) {
         return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
     }
 
-    // Preserve insertion order so the model sees the dominant type first.
+    // Preserve insertion order.
     const histogram = Object.create(null);
     const order = [];
     for (let i = 0; i < children.length; i++) {
@@ -84,18 +84,18 @@ function _renderAggregationLine(name, children) {
 }
 
 /**
- * Builds assistant prompts. Free of Chrome APIs.
+ * Builds assistant prompts.
  * @constructor
  */
 function PromptBuilder() {
 }
 
 /**
- * Build the system prompt. Optionally stitches a Current Application Context section between
- * the Role and Rules zones when `appInfo` yields recognized fields.
+ * Build the system prompt. Adds a Current Application Context section between Role and Rules
+ * when `appInfo` has usable fields.
  *
- * @param {Object} [appInfo] App metadata snapshot: `common.data`, `configurationComputed.data`,
- *     `urlParameters.data`, `loadedLibraries.data`.
+ * @param {Object} [appInfo] - `common.data`, `configurationComputed.data`, `urlParameters.data`,
+ *     `loadedLibraries.data`.
  * @returns {string}
  */
 PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
@@ -158,7 +158,7 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
         lines.push('- UI locale: ' + locale);
     }
 
-    // Presence check, not truthiness: an explicit empty or "false" value is still information.
+    // Presence check, not truthiness — `sap-ui-debug=` (empty) is still information.
     if (urlData && Object.prototype.hasOwnProperty.call(urlData, 'sap-ui-debug')) {
         lines.push('- sap-ui-debug: ' + urlData['sap-ui-debug']);
     }
@@ -182,9 +182,9 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 };
 
 /**
- * Assemble the per-turn user prompt. When Inspection Context or Recent Console Errors are
- * present, wraps the user's message in a sandwich (`User asked: ... Now answer: ...`) with a
- * middle block of curated one-line sections. Otherwise returns `userMessage` unchanged.
+ * Build the per-turn user prompt. If Inspection Context or Recent Console Errors are present,
+ * wrap the message with `User asked: ...` / `Now answer: ...` around a middle block. Otherwise
+ * return `userMessage` as-is.
  *
  * @param {string} userMessage
  * @param {Object} [inspectionContext]
@@ -250,7 +250,7 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
  * @returns {string}
  */
 PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
-    // Buffer stores oldest-first; the newest error is more useful at the top.
+    // Buffer is oldest-first; show newest at top.
     const reversed = consoleErrors.slice().reverse();
 
     const lines = reversed.map(function (entry) {
@@ -266,7 +266,7 @@ PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
 };
 
 /**
- * Truncate a rendered section body to `maxLength`, keeping the header intact.
+ * Truncate `body` to `maxLength`, keeping `header` intact.
  * @private
  */
 PromptBuilder.prototype._capSection = function (header, body, maxLength) {
@@ -299,8 +299,8 @@ PromptBuilder.prototype._renderPropertiesSection = function (properties) {
 };
 
 /**
- * Render bindings as one line each. Composite bindings (with a `parts` array) collapse to a
- * degenerate `<prop> ← <composite>` line. Circular graphs fall back to the placeholder.
+ * Render each binding as one line. Composite bindings (with a `parts` array) collapse to
+ * `<prop> ← <composite>`. Circular graphs fall back to the placeholder.
  * @private
  * @param {Object} bindings
  * @returns {string}
@@ -313,7 +313,7 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
     const self = this;
     let body;
     try {
-        // Cheap circularity probe: JSON.stringify throws on cycles.
+        // JSON.stringify throws on cycles — use it as a probe.
         JSON.stringify(bindings);
 
         const lines = Object.keys(bindings).map(function (propertyName) {
@@ -337,14 +337,14 @@ PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
         return '- ' + propertyName + ' ← <invalid>';
     }
 
-    // Composite bindings are not curated yet — emit a degenerate line.
+    // Composite bindings not handled yet.
     if (Array.isArray(binding.parts)) {
         return '- ' + propertyName + ' ← <composite>';
     }
 
     let line = '- ' + propertyName + ' ← "' + (binding.path || '') + '"';
 
-    // `null` and `undefined` print literally so the model can distinguish them from strings.
+    // Print `null` and `undefined` literally so they're distinguishable from strings.
     if (Object.prototype.hasOwnProperty.call(binding, 'value')) {
         line += ' = ' + _stringifyBindingValue(binding.value);
     }
@@ -385,8 +385,8 @@ PromptBuilder.prototype._renderAggregationsSection = function (aggregations) {
 };
 
 /**
- * Build the seed message array for a new session: a system message followed by prior
- * user/assistant turns from conversation memory.
+ * Build the seed messages for a new session: a system message followed by prior
+ * user/assistant turns.
  *
  * @param {Object} [appInfo]
  * @param {Array} [conversationMemory]

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -45,10 +45,6 @@ function _stringifyBindingValue(value) {
 }
 
 /**
- * Render one aggregation entry.
- *   - empty          → `- <name>: empty`
- *   - <= 3 children  → `- <name>: N children — id1, id2, id3`
- *   - > 3 children   → `- <name>: N children (<Type> × N, ...)`
  * @private
  */
 function _renderAggregationLine(name, children) {
@@ -328,8 +324,6 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
 };
 
 /**
- * Render one binding entry.
- *   `- <prop> ← "<path>"[ = <value>] (model: <model>[, type: <type>][, formatter: yes])`
  * @private
  */
 PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -1,26 +1,15 @@
 'use strict';
 
-// Per-section safety-net caps. The shape-driven curation below is the primary volume control;
-// these caps only trigger on adversarial inputs (a control with 500 properties, a runaway
-// aggregation, etc.). Truncation appends `... [truncated]` so the model sees the boundary.
+// Per-section size caps. Truncation appends `... [truncated]`.
 const PROPERTIES_CAP = 800;
 const BINDINGS_CAP = 800;
 const AGGREGATIONS_CAP = 400;
 const CONSOLE_ERRORS_CAP = 400;
-
-// Bindings render their resolved values inline, so a single overlarge value cannot burn the
-// whole bindings-section budget on its own.
 const BINDING_VALUE_CAP = 100;
 
-// Placeholder for adversarial input that cannot be JSON-serialized (e.g. a circular graph).
-// Kept identical to the string the previous JSON-dump implementation emitted, so log-grep
-// muscle memory keeps working.
 const UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
 
 /**
- * Stringify an arbitrary value for a prompt line. Objects go through JSON.stringify so we
- * do not accidentally emit `[object Object]`; primitives print literally. `null` and
- * `undefined` render as those exact words so the model can tell them apart from the strings.
  * @private
  * @param {*} value
  * @returns {string}
@@ -43,8 +32,6 @@ function _stringifyValue(value) {
 }
 
 /**
- * Stringify a resolved binding value for the `= <value>` segment. Truncates at ~100 chars
- * so a single overlarge value cannot burn the whole bindings-section budget on its own.
  * @private
  * @param {*} value
  * @returns {string}
@@ -59,13 +46,10 @@ function _stringifyBindingValue(value) {
 
 /**
  * Render one aggregation entry.
- *   - empty aggregation → `- <name>: empty`
- *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
- *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
+ *   - empty          → `- <name>: empty`
+ *   - <= 3 children  → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children   → `- <name>: N children (<Type> × N, ...)`
  * @private
- * @param {string} name
- * @param {Array} children
- * @returns {string}
  */
 function _renderAggregationLine(name, children) {
     if (!Array.isArray(children) || children.length === 0) {
@@ -81,9 +65,7 @@ function _renderAggregationLine(name, children) {
         return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
     }
 
-    // Type histogram, insertion order preserved so the model sees the "dominant" type first
-    // if children were listed in that order (they typically are — a Page's `content` is a
-    // Text-heavy list, then a Button tail).
+    // Preserve insertion order.
     const histogram = Object.create(null);
     const order = [];
     for (let i = 0; i < children.length; i++) {
@@ -102,26 +84,18 @@ function _renderAggregationLine(name, children) {
 }
 
 /**
- * Builds assistant prompts. Owns the system prompt, app metadata formatting, selected-control
- * formatting, truncation rules, and session seed construction. Free of Chrome APIs.
- *
+ * Builds assistant prompts.
  * @constructor
  */
 function PromptBuilder() {
 }
 
 /**
- * Build the system prompt.
+ * Build the system prompt. Adds a Current Application Context section between Role and Rules
+ * when `appInfo` has usable fields.
  *
- * Assembles four static zones — Role, Rules, Style, and a copy-me Example demonstrating the
- * prescribed uncertainty phrase — with an optional Current Application Context section stitched
- * between Role and Rules so rule 4 ("prefer runtime data … shown above") reads truthfully.
- *
- * The Current Application Context section is omitted entirely when `appInfo` yields no recognized
- * fields.
- *
- * @param {Object} [appInfo] App metadata snapshot: `common.data`, `configurationComputed.data`,
- *     `urlParameters.data`, `loadedLibraries.data`. Missing fields are silently skipped.
+ * @param {Object} [appInfo] - `common.data`, `configurationComputed.data`, `urlParameters.data`,
+ *     `loadedLibraries.data`.
  * @returns {string}
  */
 PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
@@ -153,9 +127,6 @@ PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
 };
 
 /**
- * Build the Current Application Context section from app metadata. Returns an empty string when
- * no recognized fields are present, so the caller can drop the section entirely rather than emit
- * an orphan header.
  * @private
  * @param {Object} [appInfo]
  * @returns {string}
@@ -182,17 +153,12 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
         lines.push('- Theme: ' + configData.theme);
     }
 
-    // The snapshot's field name for the UI locale is not fully pinned (see issue 01 —
-    // "language/locale field"), so accept either. Fixtures in the injected-script layer use
-    // `language`.
     const locale = configData && (configData.language || configData.locale);
     if (locale) {
         lines.push('- UI locale: ' + locale);
     }
 
-    // `sap-ui-debug` uses a presence check (not truthiness) because the spec says "only when the
-    // parameter is present" — an explicitly-empty or "false" value is still information about how
-    // the app was launched.
+    // Presence check, not truthiness — `sap-ui-debug=` (empty) is still information.
     if (urlData && Object.prototype.hasOwnProperty.call(urlData, 'sap-ui-debug')) {
         lines.push('- sap-ui-debug: ' + urlData['sap-ui-debug']);
     }
@@ -216,35 +182,9 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 };
 
 /**
- * Assemble the per-turn user prompt.
- *
- * When Inspection Context or Recent Console Errors are present, wraps the user's message in a
- * sandwich:
- *
- *   User asked: <msg>
- *
- *   Current UI5 Control Context:
- *   - Type: ...
- *   - ID: ...
- *   Properties:
- *   - key: value
- *   Bindings:
- *   - prop ← "path" = value (model: ..., type: ..., formatter: yes)
- *   Aggregations:
- *   - name: N children (Type × N, Other × M)
- *
- *   Recent Console Errors:
- *   - <message> (×N)
- *     at <frame>
- *
- *   Now answer: <msg>
- *
- * Each sub-section is emitted only when its underlying data is non-empty. When both Inspection
- * Context and Recent Console Errors are absent, returns the raw user message unchanged.
- *
- * Inspection Context is injected per prompt and never stored as Conversation Memory. Recent
- * Console Errors are likewise per-turn — the ring buffer that produces them lives in the injected
- * script layer, not in Conversation Memory.
+ * Build the per-turn user prompt. If Inspection Context or Recent Console Errors are present,
+ * wrap the message with `User asked: ...` / `Now answer: ...` around a middle block. Otherwise
+ * return `userMessage` as-is.
  *
  * @param {string} userMessage
  * @param {Object} [inspectionContext]
@@ -275,7 +215,6 @@ PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionConte
 };
 
 /**
- * Render the Current UI5 Control Context block for a single control snapshot.
  * @private
  * @param {Object} control
  * @returns {string}
@@ -286,8 +225,6 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
         '- ID: ' + (control.id || 'None')
     ];
 
-    // Each renderer returns a full section body (header + lines) or an empty string. Empty
-    // sections are dropped so we never emit an orphan "Properties:" header.
     const sections = [];
     const propertiesSection = this._renderPropertiesSection(control.properties);
     if (propertiesSection) {
@@ -307,17 +244,13 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
 };
 
 /**
- * Render the Recent Console Errors block. Errors are rendered newest-first, with each entry
- * annotated `(×N)` when count > 1 and followed by an indented `at <frame>` line when a frame
- * is present. The whole section is capped at `CONSOLE_ERRORS_CAP` — a runaway page firing
- * hundreds of distinct errors will still hit the section cap before it can dilute the prompt.
+ * Render the Recent Console Errors block, newest-first.
  * @private
  * @param {Array<{type: string, message: string, frame: string, count: number}>} consoleErrors
  * @returns {string}
  */
 PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
-    // The buffer stores oldest-first (natural FIFO). The model gets more value from the most
-    // recent error at the top, so we render in reverse.
+    // Buffer is oldest-first; show newest at top.
     const reversed = consoleErrors.slice().reverse();
 
     const lines = reversed.map(function (entry) {
@@ -333,14 +266,8 @@ PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
 };
 
 /**
- * Truncate a rendered section body to a per-section cap. Appends `... [truncated]` past the
- * cap so the model sees the boundary. The cap is applied to the *body* (lines after the
- * header) so the header stays intact.
+ * Truncate `body` to `maxLength`, keeping `header` intact.
  * @private
- * @param {string} header
- * @param {string} body
- * @param {number} maxLength
- * @returns {string}
  */
 PromptBuilder.prototype._capSection = function (header, body, maxLength) {
     if (body.length > maxLength) {
@@ -350,8 +277,6 @@ PromptBuilder.prototype._capSection = function (header, body, maxLength) {
 };
 
 /**
- * Render own properties as `- key: value` lines. Returns an empty string when the property set
- * is empty or absent, so the caller drops the section header.
  * @private
  * @param {Object} properties
  * @returns {string}
@@ -374,11 +299,8 @@ PromptBuilder.prototype._renderPropertiesSection = function (properties) {
 };
 
 /**
- * Render bindings as one line each. Composite bindings (with a `parts` array) collapse to a
- * degenerate `<prop> ← <composite>` line — a follow-up will replace this with a real
- * multi-part rendering. Circular binding graphs bail out to the `cannot serialize` placeholder
- * that the previous JSON-dump implementation emitted, keeping the invariant that adversarial
- * input never throws.
+ * Render each binding as one line. Composite bindings (with a `parts` array) collapse to
+ * `<prop> ← <composite>`. Circular graphs fall back to the placeholder.
  * @private
  * @param {Object} bindings
  * @returns {string}
@@ -391,8 +313,7 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
     const self = this;
     let body;
     try {
-        // Cheap circularity probe: JSON.stringify throws on cycles. We do not use the JSON
-        // itself; we only need the throw signal so the placeholder path stays in one place.
+        // JSON.stringify throws on cycles — use it as a probe.
         JSON.stringify(bindings);
 
         const lines = Object.keys(bindings).map(function (propertyName) {
@@ -410,32 +331,24 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
  * Render one binding entry.
  *   `- <prop> ← "<path>"[ = <value>] (model: <model>[, type: <type>][, formatter: yes])`
  * @private
- * @param {string} propertyName
- * @param {Object} binding
- * @returns {string}
  */
 PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
     if (!binding || typeof binding !== 'object') {
         return '- ' + propertyName + ' ← <invalid>';
     }
 
-    // Composite bindings are represented by a `parts` array. This issue does not curate them —
-    // see the follow-up filed in the PRD. Emit a degenerate line so the sandwich stays intact.
+    // Composite bindings not handled yet.
     if (Array.isArray(binding.parts)) {
         return '- ' + propertyName + ' ← <composite>';
     }
 
     let line = '- ' + propertyName + ' ← "' + (binding.path || '') + '"';
 
-    // `= <value>` appears only when the snapshot explicitly carries a `value` key. `null` and
-    // `undefined` print literally so the model can tell "no value" from "null value" from "the
-    // string 'undefined'".
+    // Print `null` and `undefined` literally so they're distinguishable from strings.
     if (Object.prototype.hasOwnProperty.call(binding, 'value')) {
         line += ' = ' + _stringifyBindingValue(binding.value);
     }
 
-    // Annotations. `model` falls back to `default` per the AC — a binding with a path but no
-    // explicit model is bound to the default model.
     const annotations = [];
     annotations.push('model: ' + (binding.model || 'default'));
     if (binding.type) {
@@ -450,10 +363,6 @@ PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
 };
 
 /**
- * Render own aggregations as one line each. Rules from the PRD:
- *   - empty aggregation → `- <name>: empty`
- *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
- *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
  * @private
  * @param {Object} aggregations
  * @returns {string}
@@ -476,13 +385,11 @@ PromptBuilder.prototype._renderAggregationsSection = function (aggregations) {
 };
 
 /**
- * Build the seed message array for a new session.
- *
- * Emits a leading system message from `buildSystemPrompt`, followed by user/assistant turns from
- * the supplied conversation memory. Non-user/assistant entries and empty placeholders are skipped.
+ * Build the seed messages for a new session: a system message followed by prior
+ * user/assistant turns.
  *
  * @param {Object} [appInfo]
- * @param {Array} [conversationMemory] - Prior {role, content} turns.
+ * @param {Array} [conversationMemory]
  * @returns {Array<{role: string, content: string}>}
  */
 PromptBuilder.prototype.buildSeedMessages = function (appInfo, conversationMemory) {

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -1,26 +1,15 @@
 'use strict';
 
-// Per-section safety-net caps. The shape-driven curation below is the primary volume control;
-// these caps only trigger on adversarial inputs (a control with 500 properties, a runaway
-// aggregation, etc.). Truncation appends `... [truncated]` so the model sees the boundary.
+// Safety-net caps against adversarial inputs. Truncation appends `... [truncated]`.
 const PROPERTIES_CAP = 800;
 const BINDINGS_CAP = 800;
 const AGGREGATIONS_CAP = 400;
 const CONSOLE_ERRORS_CAP = 400;
-
-// Bindings render their resolved values inline, so a single overlarge value cannot burn the
-// whole bindings-section budget on its own.
 const BINDING_VALUE_CAP = 100;
 
-// Placeholder for adversarial input that cannot be JSON-serialized (e.g. a circular graph).
-// Kept identical to the string the previous JSON-dump implementation emitted, so log-grep
-// muscle memory keeps working.
 const UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
 
 /**
- * Stringify an arbitrary value for a prompt line. Objects go through JSON.stringify so we
- * do not accidentally emit `[object Object]`; primitives print literally. `null` and
- * `undefined` render as those exact words so the model can tell them apart from the strings.
  * @private
  * @param {*} value
  * @returns {string}
@@ -43,8 +32,6 @@ function _stringifyValue(value) {
 }
 
 /**
- * Stringify a resolved binding value for the `= <value>` segment. Truncates at ~100 chars
- * so a single overlarge value cannot burn the whole bindings-section budget on its own.
  * @private
  * @param {*} value
  * @returns {string}
@@ -59,13 +46,10 @@ function _stringifyBindingValue(value) {
 
 /**
  * Render one aggregation entry.
- *   - empty aggregation → `- <name>: empty`
- *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
- *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
+ *   - empty          → `- <name>: empty`
+ *   - <= 3 children  → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children   → `- <name>: N children (<Type> × N, ...)`
  * @private
- * @param {string} name
- * @param {Array} children
- * @returns {string}
  */
 function _renderAggregationLine(name, children) {
     if (!Array.isArray(children) || children.length === 0) {
@@ -81,9 +65,7 @@ function _renderAggregationLine(name, children) {
         return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
     }
 
-    // Type histogram, insertion order preserved so the model sees the "dominant" type first
-    // if children were listed in that order (they typically are — a Page's `content` is a
-    // Text-heavy list, then a Button tail).
+    // Preserve insertion order so the model sees the dominant type first.
     const histogram = Object.create(null);
     const order = [];
     for (let i = 0; i < children.length; i++) {
@@ -102,26 +84,18 @@ function _renderAggregationLine(name, children) {
 }
 
 /**
- * Builds assistant prompts. Owns the system prompt, app metadata formatting, selected-control
- * formatting, truncation rules, and session seed construction. Free of Chrome APIs.
- *
+ * Builds assistant prompts. Free of Chrome APIs.
  * @constructor
  */
 function PromptBuilder() {
 }
 
 /**
- * Build the system prompt.
- *
- * Assembles four static zones — Role, Rules, Style, and a copy-me Example demonstrating the
- * prescribed uncertainty phrase — with an optional Current Application Context section stitched
- * between Role and Rules so rule 4 ("prefer runtime data … shown above") reads truthfully.
- *
- * The Current Application Context section is omitted entirely when `appInfo` yields no recognized
- * fields.
+ * Build the system prompt. Optionally stitches a Current Application Context section between
+ * the Role and Rules zones when `appInfo` yields recognized fields.
  *
  * @param {Object} [appInfo] App metadata snapshot: `common.data`, `configurationComputed.data`,
- *     `urlParameters.data`, `loadedLibraries.data`. Missing fields are silently skipped.
+ *     `urlParameters.data`, `loadedLibraries.data`.
  * @returns {string}
  */
 PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
@@ -153,9 +127,6 @@ PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
 };
 
 /**
- * Build the Current Application Context section from app metadata. Returns an empty string when
- * no recognized fields are present, so the caller can drop the section entirely rather than emit
- * an orphan header.
  * @private
  * @param {Object} [appInfo]
  * @returns {string}
@@ -182,17 +153,12 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
         lines.push('- Theme: ' + configData.theme);
     }
 
-    // The snapshot's field name for the UI locale is not fully pinned (see issue 01 —
-    // "language/locale field"), so accept either. Fixtures in the injected-script layer use
-    // `language`.
     const locale = configData && (configData.language || configData.locale);
     if (locale) {
         lines.push('- UI locale: ' + locale);
     }
 
-    // `sap-ui-debug` uses a presence check (not truthiness) because the spec says "only when the
-    // parameter is present" — an explicitly-empty or "false" value is still information about how
-    // the app was launched.
+    // Presence check, not truthiness: an explicit empty or "false" value is still information.
     if (urlData && Object.prototype.hasOwnProperty.call(urlData, 'sap-ui-debug')) {
         lines.push('- sap-ui-debug: ' + urlData['sap-ui-debug']);
     }
@@ -216,35 +182,9 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 };
 
 /**
- * Assemble the per-turn user prompt.
- *
- * When Inspection Context or Recent Console Errors are present, wraps the user's message in a
- * sandwich:
- *
- *   User asked: <msg>
- *
- *   Current UI5 Control Context:
- *   - Type: ...
- *   - ID: ...
- *   Properties:
- *   - key: value
- *   Bindings:
- *   - prop ← "path" = value (model: ..., type: ..., formatter: yes)
- *   Aggregations:
- *   - name: N children (Type × N, Other × M)
- *
- *   Recent Console Errors:
- *   - <message> (×N)
- *     at <frame>
- *
- *   Now answer: <msg>
- *
- * Each sub-section is emitted only when its underlying data is non-empty. When both Inspection
- * Context and Recent Console Errors are absent, returns the raw user message unchanged.
- *
- * Inspection Context is injected per prompt and never stored as Conversation Memory. Recent
- * Console Errors are likewise per-turn — the ring buffer that produces them lives in the injected
- * script layer, not in Conversation Memory.
+ * Assemble the per-turn user prompt. When Inspection Context or Recent Console Errors are
+ * present, wraps the user's message in a sandwich (`User asked: ... Now answer: ...`) with a
+ * middle block of curated one-line sections. Otherwise returns `userMessage` unchanged.
  *
  * @param {string} userMessage
  * @param {Object} [inspectionContext]
@@ -275,7 +215,6 @@ PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionConte
 };
 
 /**
- * Render the Current UI5 Control Context block for a single control snapshot.
  * @private
  * @param {Object} control
  * @returns {string}
@@ -286,8 +225,6 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
         '- ID: ' + (control.id || 'None')
     ];
 
-    // Each renderer returns a full section body (header + lines) or an empty string. Empty
-    // sections are dropped so we never emit an orphan "Properties:" header.
     const sections = [];
     const propertiesSection = this._renderPropertiesSection(control.properties);
     if (propertiesSection) {
@@ -307,17 +244,13 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
 };
 
 /**
- * Render the Recent Console Errors block. Errors are rendered newest-first, with each entry
- * annotated `(×N)` when count > 1 and followed by an indented `at <frame>` line when a frame
- * is present. The whole section is capped at `CONSOLE_ERRORS_CAP` — a runaway page firing
- * hundreds of distinct errors will still hit the section cap before it can dilute the prompt.
+ * Render the Recent Console Errors block, newest-first.
  * @private
  * @param {Array<{type: string, message: string, frame: string, count: number}>} consoleErrors
  * @returns {string}
  */
 PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
-    // The buffer stores oldest-first (natural FIFO). The model gets more value from the most
-    // recent error at the top, so we render in reverse.
+    // Buffer stores oldest-first; the newest error is more useful at the top.
     const reversed = consoleErrors.slice().reverse();
 
     const lines = reversed.map(function (entry) {
@@ -333,14 +266,8 @@ PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
 };
 
 /**
- * Truncate a rendered section body to a per-section cap. Appends `... [truncated]` past the
- * cap so the model sees the boundary. The cap is applied to the *body* (lines after the
- * header) so the header stays intact.
+ * Truncate a rendered section body to `maxLength`, keeping the header intact.
  * @private
- * @param {string} header
- * @param {string} body
- * @param {number} maxLength
- * @returns {string}
  */
 PromptBuilder.prototype._capSection = function (header, body, maxLength) {
     if (body.length > maxLength) {
@@ -350,8 +277,6 @@ PromptBuilder.prototype._capSection = function (header, body, maxLength) {
 };
 
 /**
- * Render own properties as `- key: value` lines. Returns an empty string when the property set
- * is empty or absent, so the caller drops the section header.
  * @private
  * @param {Object} properties
  * @returns {string}
@@ -375,10 +300,7 @@ PromptBuilder.prototype._renderPropertiesSection = function (properties) {
 
 /**
  * Render bindings as one line each. Composite bindings (with a `parts` array) collapse to a
- * degenerate `<prop> ← <composite>` line — a follow-up will replace this with a real
- * multi-part rendering. Circular binding graphs bail out to the `cannot serialize` placeholder
- * that the previous JSON-dump implementation emitted, keeping the invariant that adversarial
- * input never throws.
+ * degenerate `<prop> ← <composite>` line. Circular graphs fall back to the placeholder.
  * @private
  * @param {Object} bindings
  * @returns {string}
@@ -391,8 +313,7 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
     const self = this;
     let body;
     try {
-        // Cheap circularity probe: JSON.stringify throws on cycles. We do not use the JSON
-        // itself; we only need the throw signal so the placeholder path stays in one place.
+        // Cheap circularity probe: JSON.stringify throws on cycles.
         JSON.stringify(bindings);
 
         const lines = Object.keys(bindings).map(function (propertyName) {
@@ -410,32 +331,24 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
  * Render one binding entry.
  *   `- <prop> ← "<path>"[ = <value>] (model: <model>[, type: <type>][, formatter: yes])`
  * @private
- * @param {string} propertyName
- * @param {Object} binding
- * @returns {string}
  */
 PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
     if (!binding || typeof binding !== 'object') {
         return '- ' + propertyName + ' ← <invalid>';
     }
 
-    // Composite bindings are represented by a `parts` array. This issue does not curate them —
-    // see the follow-up filed in the PRD. Emit a degenerate line so the sandwich stays intact.
+    // Composite bindings are not curated yet — emit a degenerate line.
     if (Array.isArray(binding.parts)) {
         return '- ' + propertyName + ' ← <composite>';
     }
 
     let line = '- ' + propertyName + ' ← "' + (binding.path || '') + '"';
 
-    // `= <value>` appears only when the snapshot explicitly carries a `value` key. `null` and
-    // `undefined` print literally so the model can tell "no value" from "null value" from "the
-    // string 'undefined'".
+    // `null` and `undefined` print literally so the model can distinguish them from strings.
     if (Object.prototype.hasOwnProperty.call(binding, 'value')) {
         line += ' = ' + _stringifyBindingValue(binding.value);
     }
 
-    // Annotations. `model` falls back to `default` per the AC — a binding with a path but no
-    // explicit model is bound to the default model.
     const annotations = [];
     annotations.push('model: ' + (binding.model || 'default'));
     if (binding.type) {
@@ -450,10 +363,6 @@ PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
 };
 
 /**
- * Render own aggregations as one line each. Rules from the PRD:
- *   - empty aggregation → `- <name>: empty`
- *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
- *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
  * @private
  * @param {Object} aggregations
  * @returns {string}
@@ -476,13 +385,11 @@ PromptBuilder.prototype._renderAggregationsSection = function (aggregations) {
 };
 
 /**
- * Build the seed message array for a new session.
- *
- * Emits a leading system message from `buildSystemPrompt`, followed by user/assistant turns from
- * the supplied conversation memory. Non-user/assistant entries and empty placeholders are skipped.
+ * Build the seed message array for a new session: a system message followed by prior
+ * user/assistant turns from conversation memory.
  *
  * @param {Object} [appInfo]
- * @param {Array} [conversationMemory] - Prior {role, content} turns.
+ * @param {Array} [conversationMemory]
  * @returns {Array<{role: string, content: string}>}
  */
 PromptBuilder.prototype.buildSeedMessages = function (appInfo, conversationMemory) {

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -1,5 +1,105 @@
 'use strict';
 
+// Per-section safety-net caps. The shape-driven curation below is the primary volume control;
+// these caps only trigger on adversarial inputs (a control with 500 properties, a runaway
+// aggregation, etc.). Truncation appends `... [truncated]` so the model sees the boundary.
+var PROPERTIES_CAP = 800;
+var BINDINGS_CAP = 800;
+var AGGREGATIONS_CAP = 400;
+
+// Bindings render their resolved values inline, so a single overlarge value cannot burn the
+// whole bindings-section budget on its own.
+var BINDING_VALUE_CAP = 100;
+
+// Placeholder for adversarial input that cannot be JSON-serialized (e.g. a circular graph).
+// Kept identical to the string the previous JSON-dump implementation emitted, so log-grep
+// muscle memory keeps working.
+var UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
+
+/**
+ * Stringify an arbitrary value for a prompt line. Objects go through JSON.stringify so we
+ * do not accidentally emit `[object Object]`; primitives print literally. `null` and
+ * `undefined` render as those exact words so the model can tell them apart from the strings.
+ * @private
+ * @param {*} value
+ * @returns {string}
+ */
+function _stringifyValue(value) {
+    if (value === null) {
+        return 'null';
+    }
+    if (typeof value === 'undefined') {
+        return 'undefined';
+    }
+    if (typeof value === 'object') {
+        try {
+            return JSON.stringify(value);
+        } catch (e) {
+            return UNSERIALIZABLE_PLACEHOLDER;
+        }
+    }
+    return String(value);
+}
+
+/**
+ * Stringify a resolved binding value for the `= <value>` segment. Truncates at ~100 chars
+ * so a single overlarge value cannot burn the whole bindings-section budget on its own.
+ * @private
+ * @param {*} value
+ * @returns {string}
+ */
+function _stringifyBindingValue(value) {
+    var rendered = _stringifyValue(value);
+    if (rendered.length > BINDING_VALUE_CAP) {
+        return rendered.substring(0, BINDING_VALUE_CAP) + '...';
+    }
+    return rendered;
+}
+
+/**
+ * Render one aggregation entry.
+ *   - empty aggregation → `- <name>: empty`
+ *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
+ * @private
+ * @param {string} name
+ * @param {Array} children
+ * @returns {string}
+ */
+function _renderAggregationLine(name, children) {
+    if (!Array.isArray(children) || children.length === 0) {
+        return '- ' + name + ': empty';
+    }
+
+    var count = children.length;
+
+    if (count <= 3) {
+        var ids = children.map(function (child) {
+            return (child && child.id) || '?';
+        });
+        return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
+    }
+
+    // Type histogram, insertion order preserved so the model sees the "dominant" type first
+    // if children were listed in that order (they typically are — a Page's `content` is a
+    // Text-heavy list, then a Button tail).
+    var histogram = Object.create(null);
+    var order = [];
+    for (var i = 0; i < children.length; i++) {
+        var type = (children[i] && children[i].type) || '?';
+        if (!Object.prototype.hasOwnProperty.call(histogram, type)) {
+            histogram[type] = 0;
+            order.push(type);
+        }
+        histogram[type] += 1;
+    }
+    var parts = order.map(function (type) {
+        return type + ' × ' + histogram[type];
+    });
+
+    return '- ' + name + ': ' + count + ' children (' + parts.join(', ') + ')';
+}
+
 /**
  * Builds assistant prompts. Owns the system prompt, app metadata formatting, selected-control
  * formatting, truncation rules, and session seed construction. Free of Chrome APIs.
@@ -115,8 +215,26 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 };
 
 /**
- * Prefix a user prompt with a single-turn inspection context section (selected control type, id,
- * properties, bindings, aggregations). Returns the message unchanged when no context is provided.
+ * Assemble the per-turn user prompt.
+ *
+ * When Inspection Context is present, wraps the user's message in a sandwich:
+ *
+ *   User asked: <msg>
+ *
+ *   Current UI5 Control Context:
+ *   - Type: ...
+ *   - ID: ...
+ *   Properties:
+ *   - key: value
+ *   Bindings:
+ *   - prop ← "path" = value (model: ..., type: ..., formatter: yes)
+ *   Aggregations:
+ *   - name: N children (Type × N, Other × M)
+ *
+ *   Now answer: <msg>
+ *
+ * Each of the three sub-sections is emitted only when its underlying data is non-empty.
+ * When no Inspection Context is present, returns the raw user message unchanged.
  *
  * Inspection context is injected per prompt and never stored as conversation memory.
  *
@@ -129,93 +247,178 @@ PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionConte
         return userMessage;
     }
 
-    const MAX_SECTION_LENGTH = 2000;
     const control = inspectionContext.control;
-    let contextString = 'Current UI5 Control Context:\n';
-    contextString += '- Type: ' + (control.type || 'Unknown') + '\n';
-    contextString += '- ID: ' + (control.id || 'None') + '\n';
-    contextString += this._addPropertiesContext(control, MAX_SECTION_LENGTH);
-    contextString += this._addBindingsContext(control.bindings, MAX_SECTION_LENGTH);
-    contextString += this._addAggregationsContext(control.aggregations, MAX_SECTION_LENGTH);
 
-    return contextString + '\nUser Question: ' + userMessage;
-};
+    const identityLines = [
+        '- Type: ' + (control.type || 'Unknown'),
+        '- ID: ' + (control.id || 'None')
+    ];
 
-/**
- * Truncate JSON serialization to a maximum length. Returns a placeholder for circular or
- * non-serializable input.
- * @private
- * @param {*} data
- * @param {number} maxLength
- * @returns {string}
- */
-PromptBuilder.prototype._truncateJson = function (data, maxLength) {
-    try {
-        const json = JSON.stringify(data, null, 2);
-        if (json.length > maxLength) {
-            return json.substring(0, maxLength) + '... [truncated]';
-        }
-        return json;
-    } catch (e) {
-        return '(Data available but cannot serialize)';
+    // Each renderer returns a full section body (header + lines) or an empty string. Empty
+    // sections are dropped so we never emit an orphan "Properties:" header.
+    const sections = [];
+    const propertiesSection = this._renderPropertiesSection(control.properties);
+    if (propertiesSection) {
+        sections.push(propertiesSection);
     }
+    const bindingsSection = this._renderBindingsSection(control.bindings);
+    if (bindingsSection) {
+        sections.push(bindingsSection);
+    }
+    const aggregationsSection = this._renderAggregationsSection(control.aggregations);
+    if (aggregationsSection) {
+        sections.push(aggregationsSection);
+    }
+
+    const contextBody = identityLines.concat(sections).join('\n');
+    const contextBlock = 'Current UI5 Control Context:\n' + contextBody;
+
+    return 'User asked: ' + userMessage + '\n\n' +
+        contextBlock + '\n\n' +
+        'Now answer: ' + userMessage;
 };
 
 /**
- * Format control "own" properties as a truncated JSON line. Empty when there are no own properties.
+ * Truncate a rendered section body to a per-section cap. Appends `... [truncated]` past the
+ * cap so the model sees the boundary. The cap is applied to the *body* (lines after the
+ * header) so the header stays intact.
  * @private
- * @param {Object} control
+ * @param {string} header
+ * @param {string} body
  * @param {number} maxLength
  * @returns {string}
  */
-PromptBuilder.prototype._addPropertiesContext = function (control, maxLength) {
-    const props = control.properties;
-    if (!props || !props.own || !props.own.data) {
+PromptBuilder.prototype._capSection = function (header, body, maxLength) {
+    if (body.length > maxLength) {
+        return header + '\n' + body.substring(0, maxLength) + '... [truncated]';
+    }
+    return header + '\n' + body;
+};
+
+/**
+ * Render own properties as `- key: value` lines. Returns an empty string when the property set
+ * is empty or absent, so the caller drops the section header.
+ * @private
+ * @param {Object} properties
+ * @returns {string}
+ */
+PromptBuilder.prototype._renderPropertiesSection = function (properties) {
+    if (!properties || !properties.own || !properties.own.data) {
         return '';
     }
-    const keys = Object.keys(props.own.data);
+    const data = properties.own.data;
+    const keys = Object.keys(data);
     if (keys.length === 0) {
         return '';
     }
-    let propsJson = JSON.stringify(props.own.data);
-    if (propsJson.length > maxLength) {
-        propsJson = propsJson.substring(0, maxLength) + '... [truncated]';
-    }
-    return '- Properties: ' + propsJson + '\n';
+
+    const lines = keys.map(function (key) {
+        return '- ' + key + ': ' + _stringifyValue(data[key]);
+    });
+
+    return this._capSection('Properties:', lines.join('\n'), PROPERTIES_CAP);
 };
 
 /**
+ * Render bindings as one line each. Composite bindings (with a `parts` array) collapse to a
+ * degenerate `<prop> ← <composite>` line — a follow-up will replace this with a real
+ * multi-part rendering. Circular binding graphs bail out to the `cannot serialize` placeholder
+ * that the previous JSON-dump implementation emitted, keeping the invariant that adversarial
+ * input never throws.
  * @private
  * @param {Object} bindings
- * @param {number} maxLength
  * @returns {string}
  */
-PromptBuilder.prototype._addBindingsContext = function (bindings, maxLength) {
-    if (!bindings || Object.keys(bindings).length === 0) {
+PromptBuilder.prototype._renderBindingsSection = function (bindings) {
+    if (!bindings || typeof bindings !== 'object' || Object.keys(bindings).length === 0) {
         return '';
     }
-    let result = '- Bindings (' + Object.keys(bindings).length + '):\n';
-    result += this._truncateJson(bindings, maxLength) + '\n';
-    return result;
+
+    const self = this;
+    let body;
+    try {
+        // Cheap circularity probe: JSON.stringify throws on cycles. We do not use the JSON
+        // itself; we only need the throw signal so the placeholder path stays in one place.
+        JSON.stringify(bindings);
+
+        const lines = Object.keys(bindings).map(function (propertyName) {
+            return self._renderBindingLine(propertyName, bindings[propertyName]);
+        });
+        body = lines.join('\n');
+    } catch (e) {
+        body = UNSERIALIZABLE_PLACEHOLDER;
+    }
+
+    return this._capSection('Bindings:', body, BINDINGS_CAP);
 };
 
 /**
+ * Render one binding entry.
+ *   `- <prop> ← "<path>"[ = <value>] (model: <model>[, type: <type>][, formatter: yes])`
  * @private
- * @param {Object} aggregations
- * @param {number} maxLength
+ * @param {string} propertyName
+ * @param {Object} binding
  * @returns {string}
  */
-PromptBuilder.prototype._addAggregationsContext = function (aggregations, maxLength) {
+PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
+    if (!binding || typeof binding !== 'object') {
+        return '- ' + propertyName + ' ← <invalid>';
+    }
+
+    // Composite bindings are represented by a `parts` array. This issue does not curate them —
+    // see the follow-up filed in the PRD. Emit a degenerate line so the sandwich stays intact.
+    if (Array.isArray(binding.parts)) {
+        return '- ' + propertyName + ' ← <composite>';
+    }
+
+    let line = '- ' + propertyName + ' ← "' + (binding.path || '') + '"';
+
+    // `= <value>` appears only when the snapshot explicitly carries a `value` key. `null` and
+    // `undefined` print literally so the model can tell "no value" from "null value" from "the
+    // string 'undefined'".
+    if (Object.prototype.hasOwnProperty.call(binding, 'value')) {
+        line += ' = ' + _stringifyBindingValue(binding.value);
+    }
+
+    // Annotations. `model` falls back to `default` per the AC — a binding with a path but no
+    // explicit model is bound to the default model.
+    const annotations = [];
+    annotations.push('model: ' + (binding.model || 'default'));
+    if (binding.type) {
+        annotations.push('type: ' + binding.type);
+    }
+    if (binding.formatter) {
+        annotations.push('formatter: yes');
+    }
+    line += ' (' + annotations.join(', ') + ')';
+
+    return line;
+};
+
+/**
+ * Render own aggregations as one line each. Rules from the PRD:
+ *   - empty aggregation → `- <name>: empty`
+ *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
+ * @private
+ * @param {Object} aggregations
+ * @returns {string}
+ */
+PromptBuilder.prototype._renderAggregationsSection = function (aggregations) {
     if (!aggregations || !aggregations.own || !aggregations.own.data) {
         return '';
     }
-    const keys = Object.keys(aggregations.own.data);
+    const data = aggregations.own.data;
+    const keys = Object.keys(data);
     if (keys.length === 0) {
         return '';
     }
-    let result = '- Aggregations (' + keys.length + '):\n';
-    result += this._truncateJson(aggregations.own.data, maxLength) + '\n';
-    return result;
+
+    const lines = keys.map(function (name) {
+        return _renderAggregationLine(name, data[name]);
+    });
+
+    return this._capSection('Aggregations:', lines.join('\n'), AGGREGATIONS_CAP);
 };
 
 /**

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -10,41 +10,108 @@ function PromptBuilder() {
 }
 
 /**
- * Adds a Current Application Context section when app metadata is provided.
+ * Build the system prompt.
  *
- * @param {Object} [appInfo]
+ * Assembles four static zones — Role, Rules, Style, and a copy-me Example demonstrating the
+ * prescribed uncertainty phrase — with an optional Current Application Context section stitched
+ * between Role and Rules so rule 4 ("prefer runtime data … shown above") reads truthfully.
+ *
+ * The Current Application Context section is omitted entirely when `appInfo` yields no recognized
+ * fields.
+ *
+ * @param {Object} [appInfo] App metadata snapshot: `common.data`, `configurationComputed.data`,
+ *     `urlParameters.data`, `loadedLibraries.data`. Missing fields are silently skipped.
  * @returns {string}
  */
 PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
-    let prompt = 'You are an AI assistant embedded in the UI5 Inspector, specialized in SAP UI5, OpenUI5, and UI5 Web Components. Your role is to help developers understand, debug, and build UI5-based applications.\n' +
-        'Provide clear, accurate, and practical guidance on components, APIs, accessibility, theming, layout, performance, and best practices. Prefer concise answers, but explain reasoning when needed. Use code snippets where helpful and format code clearly.\n' +
-        'Assume familiarity with JavaScript, HTML, and modern frameworks. When information is uncertain or version-dependent, say so clearly. Do not invent APIs or unsupported features.\n' +
-        'You cannot browse the web or open links. If external content is required, ask the user to paste it.\n' +
-        'Be neutral, direct, and developer-focused. Avoid marketing language, unnecessary filler, and generic disclaimers. Respond in the user\'s language and adapt tone to the context.';
+    const role = 'Role:\n' +
+        'You are an assistant embedded in the UI5 Inspector, specialized in SAP UI5, OpenUI5, and UI5 Web Components — helping developers understand, debug, and build UI5-based applications.';
 
-    if (appInfo) {
-        prompt += '\n\nCurrent Application Context:\n';
+    const rules = 'Rules:\n' +
+        '1. Always reply in English, regardless of the language of the user\'s message.\n' +
+        '2. When a Current UI5 Control Context section is present in the user prompt, only reference property, aggregation, event, and binding names that appear in it. If asked about a name not listed there, say so plainly.\n' +
+        '3. When naming a specific property, event, method, or enum value on a UI5 control, only state it if confident it exists. Otherwise use this exact phrase and add no further disclaimers:\n' +
+        'I\'m not certain <name> exists on <control> — verify in the API reference.\n' +
+        '4. Prefer runtime data (resolved binding values, console errors, application metadata shown above) over general assumptions when answering.';
 
-        if (appInfo.common && appInfo.common.data) {
-            const frameworkInfo = appInfo.common.data.OpenUI5 || appInfo.common.data.SAPUI5;
-            if (frameworkInfo) {
-                prompt += '- Framework: ' + frameworkInfo + '\n';
-            }
-        }
+    const style = 'Style:\n' +
+        'Neutral, direct, and developer-focused. Use code snippets for code. No marketing filler, no generic disclaimers.';
 
-        if (appInfo.configurationComputed && appInfo.configurationComputed.data && appInfo.configurationComputed.data.theme) {
-            prompt += '- Theme: ' + appInfo.configurationComputed.data.theme + '\n';
-        }
+    const example = 'Example — uncertainty phrase in use:\n' +
+        'Bad: "Yes, sap.m.Slider has a `flashOnClick` property that lights it up."\n' +
+        'Good: "I\'m not certain flashOnClick exists on sap.m.Slider — verify in the API reference."';
 
-        if (appInfo.loadedLibraries && appInfo.loadedLibraries.data) {
-            const libraries = Object.keys(appInfo.loadedLibraries.data);
-            if (libraries.length > 0) {
-                prompt += '- Loaded Libraries: ' + libraries.join(', ') + '\n';
-            }
+    const zones = [role];
+    const appContext = this._buildAppContext(appInfo);
+    if (appContext) {
+        zones.push(appContext);
+    }
+    zones.push(rules, style, example);
+
+    return zones.join('\n\n');
+};
+
+/**
+ * Build the Current Application Context section from app metadata. Returns an empty string when
+ * no recognized fields are present, so the caller can drop the section entirely rather than emit
+ * an orphan header.
+ * @private
+ * @param {Object} [appInfo]
+ * @returns {string}
+ */
+PromptBuilder.prototype._buildAppContext = function (appInfo) {
+    if (!appInfo) {
+        return '';
+    }
+
+    const lines = [];
+    const commonData = appInfo.common && appInfo.common.data;
+    const configData = appInfo.configurationComputed && appInfo.configurationComputed.data;
+    const urlData = appInfo.urlParameters && appInfo.urlParameters.data;
+    const libsData = appInfo.loadedLibraries && appInfo.loadedLibraries.data;
+
+    if (commonData) {
+        const frameworkInfo = commonData.OpenUI5 || commonData.SAPUI5;
+        if (frameworkInfo) {
+            lines.push('- Framework: ' + frameworkInfo);
         }
     }
 
-    return prompt;
+    if (configData && configData.theme) {
+        lines.push('- Theme: ' + configData.theme);
+    }
+
+    // The snapshot's field name for the UI locale is not fully pinned (see issue 01 —
+    // "language/locale field"), so accept either. Fixtures in the injected-script layer use
+    // `language`.
+    const locale = configData && (configData.language || configData.locale);
+    if (locale) {
+        lines.push('- UI locale: ' + locale);
+    }
+
+    // `sap-ui-debug` uses a presence check (not truthiness) because the spec says "only when the
+    // parameter is present" — an explicitly-empty or "false" value is still information about how
+    // the app was launched.
+    if (urlData && Object.prototype.hasOwnProperty.call(urlData, 'sap-ui-debug')) {
+        lines.push('- sap-ui-debug: ' + urlData['sap-ui-debug']);
+    }
+
+    if (commonData && commonData.Application) {
+        lines.push('- Application entry point: ' + commonData.Application);
+    }
+
+    if (libsData) {
+        const libraries = Object.keys(libsData);
+        if (libraries.length > 0) {
+            lines.push('- Loaded Libraries: ' + libraries.join(', '));
+        }
+    }
+
+    if (lines.length === 0) {
+        return '';
+    }
+
+    return 'Current Application Context:\n' + lines.join('\n');
 };
 
 /**

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -6,6 +6,7 @@
 const PROPERTIES_CAP = 800;
 const BINDINGS_CAP = 800;
 const AGGREGATIONS_CAP = 400;
+const CONSOLE_ERRORS_CAP = 400;
 
 // Bindings render their resolved values inline, so a single overlarge value cannot burn the
 // whole bindings-section budget on its own.
@@ -217,7 +218,8 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 /**
  * Assemble the per-turn user prompt.
  *
- * When Inspection Context is present, wraps the user's message in a sandwich:
+ * When Inspection Context or Recent Console Errors are present, wraps the user's message in a
+ * sandwich:
  *
  *   User asked: <msg>
  *
@@ -231,24 +233,54 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
  *   Aggregations:
  *   - name: N children (Type × N, Other × M)
  *
+ *   Recent Console Errors:
+ *   - <message> (×N)
+ *     at <frame>
+ *
  *   Now answer: <msg>
  *
- * Each of the three sub-sections is emitted only when its underlying data is non-empty.
- * When no Inspection Context is present, returns the raw user message unchanged.
+ * Each sub-section is emitted only when its underlying data is non-empty. When both Inspection
+ * Context and Recent Console Errors are absent, returns the raw user message unchanged.
  *
- * Inspection context is injected per prompt and never stored as conversation memory.
+ * Inspection Context is injected per prompt and never stored as Conversation Memory. Recent
+ * Console Errors are likewise per-turn — the ring buffer that produces them lives in the injected
+ * script layer, not in Conversation Memory.
  *
  * @param {string} userMessage
  * @param {Object} [inspectionContext]
+ * @param {Array<{type: string, message: string, frame: string, count: number}>} [consoleErrors]
  * @returns {string}
  */
-PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionContext) {
-    if (!inspectionContext || !inspectionContext.control) {
+PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionContext, consoleErrors) {
+    const hasControl = inspectionContext && inspectionContext.control;
+    const hasErrors = Array.isArray(consoleErrors) && consoleErrors.length > 0;
+
+    if (!hasControl && !hasErrors) {
         return userMessage;
     }
 
-    const control = inspectionContext.control;
+    const middleSections = [];
 
+    if (hasControl) {
+        middleSections.push(this._buildControlContextBlock(inspectionContext.control));
+    }
+
+    if (hasErrors) {
+        middleSections.push(this._buildConsoleErrorsBlock(consoleErrors));
+    }
+
+    return 'User asked: ' + userMessage + '\n\n' +
+        middleSections.join('\n\n') + '\n\n' +
+        'Now answer: ' + userMessage;
+};
+
+/**
+ * Render the Current UI5 Control Context block for a single control snapshot.
+ * @private
+ * @param {Object} control
+ * @returns {string}
+ */
+PromptBuilder.prototype._buildControlContextBlock = function (control) {
     const identityLines = [
         '- Type: ' + (control.type || 'Unknown'),
         '- ID: ' + (control.id || 'None')
@@ -271,11 +303,33 @@ PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionConte
     }
 
     const contextBody = identityLines.concat(sections).join('\n');
-    const contextBlock = 'Current UI5 Control Context:\n' + contextBody;
+    return 'Current UI5 Control Context:\n' + contextBody;
+};
 
-    return 'User asked: ' + userMessage + '\n\n' +
-        contextBlock + '\n\n' +
-        'Now answer: ' + userMessage;
+/**
+ * Render the Recent Console Errors block. Errors are rendered newest-first, with each entry
+ * annotated `(×N)` when count > 1 and followed by an indented `at <frame>` line when a frame
+ * is present. The whole section is capped at `CONSOLE_ERRORS_CAP` — a runaway page firing
+ * hundreds of distinct errors will still hit the section cap before it can dilute the prompt.
+ * @private
+ * @param {Array<{type: string, message: string, frame: string, count: number}>} consoleErrors
+ * @returns {string}
+ */
+PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
+    // The buffer stores oldest-first (natural FIFO). The model gets more value from the most
+    // recent error at the top, so we render in reverse.
+    const reversed = consoleErrors.slice().reverse();
+
+    const lines = reversed.map(function (entry) {
+        const count = entry.count > 1 ? ' (×' + entry.count + ')' : '';
+        let line = '- ' + entry.message + count;
+        if (entry.frame) {
+            line += '\n  at ' + entry.frame;
+        }
+        return line;
+    });
+
+    return this._capSection('Recent Console Errors:', lines.join('\n'), CONSOLE_ERRORS_CAP);
 };
 
 /**

--- a/app/scripts/modules/ai/PromptBuilder.js
+++ b/app/scripts/modules/ai/PromptBuilder.js
@@ -1,15 +1,26 @@
 'use strict';
 
-// Per-section size caps. Truncation appends `... [truncated]`.
+// Per-section safety-net caps. The shape-driven curation below is the primary volume control;
+// these caps only trigger on adversarial inputs (a control with 500 properties, a runaway
+// aggregation, etc.). Truncation appends `... [truncated]` so the model sees the boundary.
 const PROPERTIES_CAP = 800;
 const BINDINGS_CAP = 800;
 const AGGREGATIONS_CAP = 400;
 const CONSOLE_ERRORS_CAP = 400;
+
+// Bindings render their resolved values inline, so a single overlarge value cannot burn the
+// whole bindings-section budget on its own.
 const BINDING_VALUE_CAP = 100;
 
+// Placeholder for adversarial input that cannot be JSON-serialized (e.g. a circular graph).
+// Kept identical to the string the previous JSON-dump implementation emitted, so log-grep
+// muscle memory keeps working.
 const UNSERIALIZABLE_PLACEHOLDER = '(Data available but cannot serialize)';
 
 /**
+ * Stringify an arbitrary value for a prompt line. Objects go through JSON.stringify so we
+ * do not accidentally emit `[object Object]`; primitives print literally. `null` and
+ * `undefined` render as those exact words so the model can tell them apart from the strings.
  * @private
  * @param {*} value
  * @returns {string}
@@ -32,6 +43,8 @@ function _stringifyValue(value) {
 }
 
 /**
+ * Stringify a resolved binding value for the `= <value>` segment. Truncates at ~100 chars
+ * so a single overlarge value cannot burn the whole bindings-section budget on its own.
  * @private
  * @param {*} value
  * @returns {string}
@@ -46,10 +59,13 @@ function _stringifyBindingValue(value) {
 
 /**
  * Render one aggregation entry.
- *   - empty          → `- <name>: empty`
- *   - <= 3 children  → `- <name>: N children — id1, id2, id3`
- *   - > 3 children   → `- <name>: N children (<Type> × N, ...)`
+ *   - empty aggregation → `- <name>: empty`
+ *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
  * @private
+ * @param {string} name
+ * @param {Array} children
+ * @returns {string}
  */
 function _renderAggregationLine(name, children) {
     if (!Array.isArray(children) || children.length === 0) {
@@ -65,7 +81,9 @@ function _renderAggregationLine(name, children) {
         return '- ' + name + ': ' + count + ' children — ' + ids.join(', ');
     }
 
-    // Preserve insertion order.
+    // Type histogram, insertion order preserved so the model sees the "dominant" type first
+    // if children were listed in that order (they typically are — a Page's `content` is a
+    // Text-heavy list, then a Button tail).
     const histogram = Object.create(null);
     const order = [];
     for (let i = 0; i < children.length; i++) {
@@ -84,18 +102,26 @@ function _renderAggregationLine(name, children) {
 }
 
 /**
- * Builds assistant prompts.
+ * Builds assistant prompts. Owns the system prompt, app metadata formatting, selected-control
+ * formatting, truncation rules, and session seed construction. Free of Chrome APIs.
+ *
  * @constructor
  */
 function PromptBuilder() {
 }
 
 /**
- * Build the system prompt. Adds a Current Application Context section between Role and Rules
- * when `appInfo` has usable fields.
+ * Build the system prompt.
  *
- * @param {Object} [appInfo] - `common.data`, `configurationComputed.data`, `urlParameters.data`,
- *     `loadedLibraries.data`.
+ * Assembles four static zones — Role, Rules, Style, and a copy-me Example demonstrating the
+ * prescribed uncertainty phrase — with an optional Current Application Context section stitched
+ * between Role and Rules so rule 4 ("prefer runtime data … shown above") reads truthfully.
+ *
+ * The Current Application Context section is omitted entirely when `appInfo` yields no recognized
+ * fields.
+ *
+ * @param {Object} [appInfo] App metadata snapshot: `common.data`, `configurationComputed.data`,
+ *     `urlParameters.data`, `loadedLibraries.data`. Missing fields are silently skipped.
  * @returns {string}
  */
 PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
@@ -127,6 +153,9 @@ PromptBuilder.prototype.buildSystemPrompt = function (appInfo) {
 };
 
 /**
+ * Build the Current Application Context section from app metadata. Returns an empty string when
+ * no recognized fields are present, so the caller can drop the section entirely rather than emit
+ * an orphan header.
  * @private
  * @param {Object} [appInfo]
  * @returns {string}
@@ -153,12 +182,17 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
         lines.push('- Theme: ' + configData.theme);
     }
 
+    // The snapshot's field name for the UI locale is not fully pinned (see issue 01 —
+    // "language/locale field"), so accept either. Fixtures in the injected-script layer use
+    // `language`.
     const locale = configData && (configData.language || configData.locale);
     if (locale) {
         lines.push('- UI locale: ' + locale);
     }
 
-    // Presence check, not truthiness — `sap-ui-debug=` (empty) is still information.
+    // `sap-ui-debug` uses a presence check (not truthiness) because the spec says "only when the
+    // parameter is present" — an explicitly-empty or "false" value is still information about how
+    // the app was launched.
     if (urlData && Object.prototype.hasOwnProperty.call(urlData, 'sap-ui-debug')) {
         lines.push('- sap-ui-debug: ' + urlData['sap-ui-debug']);
     }
@@ -182,9 +216,35 @@ PromptBuilder.prototype._buildAppContext = function (appInfo) {
 };
 
 /**
- * Build the per-turn user prompt. If Inspection Context or Recent Console Errors are present,
- * wrap the message with `User asked: ...` / `Now answer: ...` around a middle block. Otherwise
- * return `userMessage` as-is.
+ * Assemble the per-turn user prompt.
+ *
+ * When Inspection Context or Recent Console Errors are present, wraps the user's message in a
+ * sandwich:
+ *
+ *   User asked: <msg>
+ *
+ *   Current UI5 Control Context:
+ *   - Type: ...
+ *   - ID: ...
+ *   Properties:
+ *   - key: value
+ *   Bindings:
+ *   - prop ← "path" = value (model: ..., type: ..., formatter: yes)
+ *   Aggregations:
+ *   - name: N children (Type × N, Other × M)
+ *
+ *   Recent Console Errors:
+ *   - <message> (×N)
+ *     at <frame>
+ *
+ *   Now answer: <msg>
+ *
+ * Each sub-section is emitted only when its underlying data is non-empty. When both Inspection
+ * Context and Recent Console Errors are absent, returns the raw user message unchanged.
+ *
+ * Inspection Context is injected per prompt and never stored as Conversation Memory. Recent
+ * Console Errors are likewise per-turn — the ring buffer that produces them lives in the injected
+ * script layer, not in Conversation Memory.
  *
  * @param {string} userMessage
  * @param {Object} [inspectionContext]
@@ -215,6 +275,7 @@ PromptBuilder.prototype.buildUserPrompt = function (userMessage, inspectionConte
 };
 
 /**
+ * Render the Current UI5 Control Context block for a single control snapshot.
  * @private
  * @param {Object} control
  * @returns {string}
@@ -225,6 +286,8 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
         '- ID: ' + (control.id || 'None')
     ];
 
+    // Each renderer returns a full section body (header + lines) or an empty string. Empty
+    // sections are dropped so we never emit an orphan "Properties:" header.
     const sections = [];
     const propertiesSection = this._renderPropertiesSection(control.properties);
     if (propertiesSection) {
@@ -244,13 +307,17 @@ PromptBuilder.prototype._buildControlContextBlock = function (control) {
 };
 
 /**
- * Render the Recent Console Errors block, newest-first.
+ * Render the Recent Console Errors block. Errors are rendered newest-first, with each entry
+ * annotated `(×N)` when count > 1 and followed by an indented `at <frame>` line when a frame
+ * is present. The whole section is capped at `CONSOLE_ERRORS_CAP` — a runaway page firing
+ * hundreds of distinct errors will still hit the section cap before it can dilute the prompt.
  * @private
  * @param {Array<{type: string, message: string, frame: string, count: number}>} consoleErrors
  * @returns {string}
  */
 PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
-    // Buffer is oldest-first; show newest at top.
+    // The buffer stores oldest-first (natural FIFO). The model gets more value from the most
+    // recent error at the top, so we render in reverse.
     const reversed = consoleErrors.slice().reverse();
 
     const lines = reversed.map(function (entry) {
@@ -266,8 +333,14 @@ PromptBuilder.prototype._buildConsoleErrorsBlock = function (consoleErrors) {
 };
 
 /**
- * Truncate `body` to `maxLength`, keeping `header` intact.
+ * Truncate a rendered section body to a per-section cap. Appends `... [truncated]` past the
+ * cap so the model sees the boundary. The cap is applied to the *body* (lines after the
+ * header) so the header stays intact.
  * @private
+ * @param {string} header
+ * @param {string} body
+ * @param {number} maxLength
+ * @returns {string}
  */
 PromptBuilder.prototype._capSection = function (header, body, maxLength) {
     if (body.length > maxLength) {
@@ -277,6 +350,8 @@ PromptBuilder.prototype._capSection = function (header, body, maxLength) {
 };
 
 /**
+ * Render own properties as `- key: value` lines. Returns an empty string when the property set
+ * is empty or absent, so the caller drops the section header.
  * @private
  * @param {Object} properties
  * @returns {string}
@@ -299,8 +374,11 @@ PromptBuilder.prototype._renderPropertiesSection = function (properties) {
 };
 
 /**
- * Render each binding as one line. Composite bindings (with a `parts` array) collapse to
- * `<prop> ← <composite>`. Circular graphs fall back to the placeholder.
+ * Render bindings as one line each. Composite bindings (with a `parts` array) collapse to a
+ * degenerate `<prop> ← <composite>` line — a follow-up will replace this with a real
+ * multi-part rendering. Circular binding graphs bail out to the `cannot serialize` placeholder
+ * that the previous JSON-dump implementation emitted, keeping the invariant that adversarial
+ * input never throws.
  * @private
  * @param {Object} bindings
  * @returns {string}
@@ -313,7 +391,8 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
     const self = this;
     let body;
     try {
-        // JSON.stringify throws on cycles — use it as a probe.
+        // Cheap circularity probe: JSON.stringify throws on cycles. We do not use the JSON
+        // itself; we only need the throw signal so the placeholder path stays in one place.
         JSON.stringify(bindings);
 
         const lines = Object.keys(bindings).map(function (propertyName) {
@@ -331,24 +410,32 @@ PromptBuilder.prototype._renderBindingsSection = function (bindings) {
  * Render one binding entry.
  *   `- <prop> ← "<path>"[ = <value>] (model: <model>[, type: <type>][, formatter: yes])`
  * @private
+ * @param {string} propertyName
+ * @param {Object} binding
+ * @returns {string}
  */
 PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
     if (!binding || typeof binding !== 'object') {
         return '- ' + propertyName + ' ← <invalid>';
     }
 
-    // Composite bindings not handled yet.
+    // Composite bindings are represented by a `parts` array. This issue does not curate them —
+    // see the follow-up filed in the PRD. Emit a degenerate line so the sandwich stays intact.
     if (Array.isArray(binding.parts)) {
         return '- ' + propertyName + ' ← <composite>';
     }
 
     let line = '- ' + propertyName + ' ← "' + (binding.path || '') + '"';
 
-    // Print `null` and `undefined` literally so they're distinguishable from strings.
+    // `= <value>` appears only when the snapshot explicitly carries a `value` key. `null` and
+    // `undefined` print literally so the model can tell "no value" from "null value" from "the
+    // string 'undefined'".
     if (Object.prototype.hasOwnProperty.call(binding, 'value')) {
         line += ' = ' + _stringifyBindingValue(binding.value);
     }
 
+    // Annotations. `model` falls back to `default` per the AC — a binding with a path but no
+    // explicit model is bound to the default model.
     const annotations = [];
     annotations.push('model: ' + (binding.model || 'default'));
     if (binding.type) {
@@ -363,6 +450,10 @@ PromptBuilder.prototype._renderBindingLine = function (propertyName, binding) {
 };
 
 /**
+ * Render own aggregations as one line each. Rules from the PRD:
+ *   - empty aggregation → `- <name>: empty`
+ *   - ≤ 3 children       → `- <name>: N children — id1, id2, id3`
+ *   - > 3 children       → `- <name>: N children (<Type> × N, ...)`
  * @private
  * @param {Object} aggregations
  * @returns {string}
@@ -385,11 +476,13 @@ PromptBuilder.prototype._renderAggregationsSection = function (aggregations) {
 };
 
 /**
- * Build the seed messages for a new session: a system message followed by prior
- * user/assistant turns.
+ * Build the seed message array for a new session.
+ *
+ * Emits a leading system message from `buildSystemPrompt`, followed by user/assistant turns from
+ * the supplied conversation memory. Non-user/assistant entries and empty placeholders are skipped.
  *
  * @param {Object} [appInfo]
- * @param {Array} [conversationMemory]
+ * @param {Array} [conversationMemory] - Prior {role, content} turns.
  * @returns {Array<{role: string, content: string}>}
  */
 PromptBuilder.prototype.buildSeedMessages = function (appInfo, conversationMemory) {

--- a/app/scripts/modules/ai/PromptClient.js
+++ b/app/scripts/modules/ai/PromptClient.js
@@ -289,6 +289,18 @@ PromptClient.prototype.promptStreaming = function (formattedUserMessage) {
 };
 
 /**
+ * Whether the transport currently has an active local AI session. Flips to `false` when the
+ * background port disconnects (e.g. Chrome killed the idle service worker) so the Assistant
+ * Controller can reseed lazily on the next Send instead of surfacing the "No active session"
+ * guard as a `streaming-failed` banner.
+ *
+ * @returns {boolean}
+ */
+PromptClient.prototype.hasActiveSession = function () {
+    return this._hasActiveSession;
+};
+
+/**
  * @returns {Promise<Object|null>} {inputUsage, inputQuota, percentUsed} or null.
  */
 PromptClient.prototype.getUsageInfo = function () {

--- a/app/scripts/modules/injected/consoleErrorBuffer.js
+++ b/app/scripts/modules/injected/consoleErrorBuffer.js
@@ -1,14 +1,8 @@
 'use strict';
 
 /**
- * Pure state machine over an error-event stream. No browser or Chrome dependencies — the
- * browser-side glue (attaching listeners, monkey-patching console methods) is a thin adapter
- * around this module, so the buffer semantics can be unit-tested without a running page.
- *
- * The buffer is a bounded FIFO of the three most-recent, deduplicated console errors and
- * warnings from the inspected page. Recency is defined by *first arrival*: when a new event
- * hashes to the same key as an existing entry the entry's count increments but the entry does
- * not move to the front.
+ * Bounded FIFO of the N most-recent deduplicated console errors and warnings. Duplicates
+ * increment `count` on the existing entry and do not re-promote. No browser deps.
  */
 
 const CAPACITY = 3;
@@ -19,11 +13,7 @@ const FRAMEWORK_FRAME_PATTERNS = [
 ];
 
 /**
- * Normalize a message for dedup-key computation. Collapses runs of whitespace so a message
- * that differs only in incidental spacing hashes to the same key.
  * @private
- * @param {string} message
- * @returns {string}
  */
 function _normalizeMessage(message) {
     if (typeof message !== 'string') {
@@ -33,12 +23,7 @@ function _normalizeMessage(message) {
 }
 
 /**
- * Test whether a single stack-frame line looks like framework code that the model should not be
- * pointed at. The heuristics match the paths a UI5 app produces both when loaded from a bootstrap
- * CDN (`sap-ui-core.js`) and when it references a library file (`resources/sap/...`).
  * @private
- * @param {string} frame
- * @returns {boolean}
  */
 function _isFrameworkFrame(frame) {
     for (let i = 0; i < FRAMEWORK_FRAME_PATTERNS.length; i++) {
@@ -50,23 +35,15 @@ function _isFrameworkFrame(frame) {
 }
 
 /**
- * Select the top non-framework frame from a stack string. Skips up to `MAX_FRAME_SKIPS`
- * framework frames total, then falls back to whatever frame we landed on — the model gets
- * *something* rather than an empty pointer even if the whole stack is framework code.
- *
- * A "frame" here is a single non-empty, non-"Error"-header line from the stack string.
- *
+ * Pick the top non-framework frame. Skips up to `MAX_FRAME_SKIPS` framework frames, then
+ * falls back to whichever frame we're on.
  * @private
- * @param {string} stack
- * @returns {string} the selected frame trimmed, or empty string when the stack has no frames.
  */
 function _selectTopFrame(stack) {
     if (typeof stack !== 'string' || stack.length === 0) {
         return '';
     }
 
-    // The first line is usually the message header (`Error: something`) — drop it. Any subsequent
-    // blank line or the header line itself is filtered out below.
     const lines = stack.split('\n');
     const frames = [];
     for (let i = 0; i < lines.length; i++) {
@@ -74,7 +51,7 @@ function _selectTopFrame(stack) {
         if (!trimmed) {
             continue;
         }
-        // Header line without an `at ` prefix and no obvious location — treat as non-frame.
+        // Drop the "Error: ..." header line (no `at ` prefix on line 0).
         if (i === 0 && trimmed.indexOf('at ') !== 0) {
             continue;
         }
@@ -93,39 +70,25 @@ function _selectTopFrame(stack) {
         skips += 1;
     }
 
-    // All frames were framework and we exhausted the skip budget — return the last one we saw.
     return frames[frames.length - 1];
 }
 
 /**
- * Build the dedup key for an event. `(normalized message, top-shown stack frame)` per the PRD.
  * @private
- * @param {string} normalizedMessage
- * @param {string} frame
- * @returns {string}
  */
 function _dedupKey(normalizedMessage, frame) {
     return normalizedMessage + '\u0000' + frame;
 }
 
 /**
- * Create a new console-error buffer instance. Each call returns a fresh, independent buffer;
- * the module exports no shared state.
- *
  * @returns {{record: Function, snapshot: Function, clear: Function}}
  */
 function create() {
     let entries = [];
-    // Index by dedup key so record() is O(1) on the hot path when errors flood in.
     let indexByKey = Object.create(null);
 
     return {
         /**
-         * Record an event. Shape: `{ type: 'error' | 'warn' | 'uncaught', message, stack? }`.
-         * A duplicate (same dedup key as an existing entry) increments the count on the
-         * existing entry and is *not* promoted to the front. A new distinct entry appends;
-         * once the buffer is at capacity the oldest entry is evicted.
-         *
          * @param {{type: string, message: string, stack?: string}} event
          */
         record: function (event) {
@@ -154,7 +117,6 @@ function create() {
 
             if (entries.length > CAPACITY) {
                 const evicted = entries.shift();
-                // Rebuild the key -> entry index for the surviving entries. Cheap at N = 3.
                 const evictedKey = _dedupKey(evicted.message, evicted.frame);
                 delete indexByKey[evictedKey];
             }
@@ -162,7 +124,6 @@ function create() {
 
         /**
          * @returns {Array<{type: string, message: string, frame: string, count: number}>}
-         *   A shallow-copied snapshot; mutating it does not affect the internal buffer.
          */
         snapshot: function () {
             return entries.map(function (e) {
@@ -175,9 +136,6 @@ function create() {
             });
         },
 
-        /**
-         * Empty the buffer. Called by the panel on URL change and Clear Conversation.
-         */
         clear: function () {
             entries = [];
             indexByKey = Object.create(null);

--- a/app/scripts/modules/injected/consoleErrorBuffer.js
+++ b/app/scripts/modules/injected/consoleErrorBuffer.js
@@ -1,14 +1,9 @@
 'use strict';
 
 /**
- * Pure state machine over an error-event stream. No browser or Chrome dependencies — the
- * browser-side glue (attaching listeners, monkey-patching console methods) is a thin adapter
- * around this module, so the buffer semantics can be unit-tested without a running page.
- *
- * The buffer is a bounded FIFO of the three most-recent, deduplicated console errors and
- * warnings from the inspected page. Recency is defined by *first arrival*: when a new event
- * hashes to the same key as an existing entry the entry's count increments but the entry does
- * not move to the front.
+ * Bounded FIFO of the N most-recent deduplicated console errors/warnings from the inspected
+ * page. Duplicates (same dedup key) increment `count` on the existing entry and do NOT
+ * re-promote. Pure state machine — no browser deps.
  */
 
 const CAPACITY = 3;
@@ -19,11 +14,7 @@ const FRAMEWORK_FRAME_PATTERNS = [
 ];
 
 /**
- * Normalize a message for dedup-key computation. Collapses runs of whitespace so a message
- * that differs only in incidental spacing hashes to the same key.
  * @private
- * @param {string} message
- * @returns {string}
  */
 function _normalizeMessage(message) {
     if (typeof message !== 'string') {
@@ -33,12 +24,7 @@ function _normalizeMessage(message) {
 }
 
 /**
- * Test whether a single stack-frame line looks like framework code that the model should not be
- * pointed at. The heuristics match the paths a UI5 app produces both when loaded from a bootstrap
- * CDN (`sap-ui-core.js`) and when it references a library file (`resources/sap/...`).
  * @private
- * @param {string} frame
- * @returns {boolean}
  */
 function _isFrameworkFrame(frame) {
     for (let i = 0; i < FRAMEWORK_FRAME_PATTERNS.length; i++) {
@@ -51,22 +37,14 @@ function _isFrameworkFrame(frame) {
 
 /**
  * Select the top non-framework frame from a stack string. Skips up to `MAX_FRAME_SKIPS`
- * framework frames total, then falls back to whatever frame we landed on — the model gets
- * *something* rather than an empty pointer even if the whole stack is framework code.
- *
- * A "frame" here is a single non-empty, non-"Error"-header line from the stack string.
- *
+ * framework frames, then falls back to whatever frame we landed on.
  * @private
- * @param {string} stack
- * @returns {string} the selected frame trimmed, or empty string when the stack has no frames.
  */
 function _selectTopFrame(stack) {
     if (typeof stack !== 'string' || stack.length === 0) {
         return '';
     }
 
-    // The first line is usually the message header (`Error: something`) — drop it. Any subsequent
-    // blank line or the header line itself is filtered out below.
     const lines = stack.split('\n');
     const frames = [];
     for (let i = 0; i < lines.length; i++) {
@@ -74,7 +52,7 @@ function _selectTopFrame(stack) {
         if (!trimmed) {
             continue;
         }
-        // Header line without an `at ` prefix and no obvious location — treat as non-frame.
+        // Drop the "Error: ..." header line (no `at ` prefix on line 0).
         if (i === 0 && trimmed.indexOf('at ') !== 0) {
             continue;
         }
@@ -93,39 +71,25 @@ function _selectTopFrame(stack) {
         skips += 1;
     }
 
-    // All frames were framework and we exhausted the skip budget — return the last one we saw.
     return frames[frames.length - 1];
 }
 
 /**
- * Build the dedup key for an event. `(normalized message, top-shown stack frame)` per the PRD.
  * @private
- * @param {string} normalizedMessage
- * @param {string} frame
- * @returns {string}
  */
 function _dedupKey(normalizedMessage, frame) {
     return normalizedMessage + '\u0000' + frame;
 }
 
 /**
- * Create a new console-error buffer instance. Each call returns a fresh, independent buffer;
- * the module exports no shared state.
- *
  * @returns {{record: Function, snapshot: Function, clear: Function}}
  */
 function create() {
     let entries = [];
-    // Index by dedup key so record() is O(1) on the hot path when errors flood in.
     let indexByKey = Object.create(null);
 
     return {
         /**
-         * Record an event. Shape: `{ type: 'error' | 'warn' | 'uncaught', message, stack? }`.
-         * A duplicate (same dedup key as an existing entry) increments the count on the
-         * existing entry and is *not* promoted to the front. A new distinct entry appends;
-         * once the buffer is at capacity the oldest entry is evicted.
-         *
          * @param {{type: string, message: string, stack?: string}} event
          */
         record: function (event) {
@@ -154,7 +118,6 @@ function create() {
 
             if (entries.length > CAPACITY) {
                 const evicted = entries.shift();
-                // Rebuild the key -> entry index for the surviving entries. Cheap at N = 3.
                 const evictedKey = _dedupKey(evicted.message, evicted.frame);
                 delete indexByKey[evictedKey];
             }
@@ -162,7 +125,6 @@ function create() {
 
         /**
          * @returns {Array<{type: string, message: string, frame: string, count: number}>}
-         *   A shallow-copied snapshot; mutating it does not affect the internal buffer.
          */
         snapshot: function () {
             return entries.map(function (e) {
@@ -175,9 +137,6 @@ function create() {
             });
         },
 
-        /**
-         * Empty the buffer. Called by the panel on URL change and Clear Conversation.
-         */
         clear: function () {
             entries = [];
             indexByKey = Object.create(null);

--- a/app/scripts/modules/injected/consoleErrorBuffer.js
+++ b/app/scripts/modules/injected/consoleErrorBuffer.js
@@ -1,9 +1,8 @@
 'use strict';
 
 /**
- * Bounded FIFO of the N most-recent deduplicated console errors/warnings from the inspected
- * page. Duplicates (same dedup key) increment `count` on the existing entry and do NOT
- * re-promote. Pure state machine — no browser deps.
+ * Bounded FIFO of the N most-recent deduplicated console errors and warnings. Duplicates
+ * increment `count` on the existing entry and do not re-promote. No browser deps.
  */
 
 const CAPACITY = 3;
@@ -36,8 +35,8 @@ function _isFrameworkFrame(frame) {
 }
 
 /**
- * Select the top non-framework frame from a stack string. Skips up to `MAX_FRAME_SKIPS`
- * framework frames, then falls back to whatever frame we landed on.
+ * Pick the top non-framework frame. Skips up to `MAX_FRAME_SKIPS` framework frames, then
+ * falls back to whichever frame we're on.
  * @private
  */
 function _selectTopFrame(stack) {

--- a/app/scripts/modules/injected/consoleErrorBuffer.js
+++ b/app/scripts/modules/injected/consoleErrorBuffer.js
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * Pure state machine over an error-event stream. No browser or Chrome dependencies — the
+ * browser-side glue (attaching listeners, monkey-patching console methods) is a thin adapter
+ * around this module, so the buffer semantics can be unit-tested without a running page.
+ *
+ * The buffer is a bounded FIFO of the three most-recent, deduplicated console errors and
+ * warnings from the inspected page. Recency is defined by *first arrival*: when a new event
+ * hashes to the same key as an existing entry the entry's count increments but the entry does
+ * not move to the front.
+ */
+
+const CAPACITY = 3;
+const MAX_FRAME_SKIPS = 3;
+const FRAMEWORK_FRAME_PATTERNS = [
+    /sap-ui-core\.js/,
+    /resources\/sap\//
+];
+
+/**
+ * Normalize a message for dedup-key computation. Collapses runs of whitespace so a message
+ * that differs only in incidental spacing hashes to the same key.
+ * @private
+ * @param {string} message
+ * @returns {string}
+ */
+function _normalizeMessage(message) {
+    if (typeof message !== 'string') {
+        return String(message === null || message === undefined ? '' : message);
+    }
+    return message.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Test whether a single stack-frame line looks like framework code that the model should not be
+ * pointed at. The heuristics match the paths a UI5 app produces both when loaded from a bootstrap
+ * CDN (`sap-ui-core.js`) and when it references a library file (`resources/sap/...`).
+ * @private
+ * @param {string} frame
+ * @returns {boolean}
+ */
+function _isFrameworkFrame(frame) {
+    for (let i = 0; i < FRAMEWORK_FRAME_PATTERNS.length; i++) {
+        if (FRAMEWORK_FRAME_PATTERNS[i].test(frame)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Select the top non-framework frame from a stack string. Skips up to `MAX_FRAME_SKIPS`
+ * framework frames total, then falls back to whatever frame we landed on — the model gets
+ * *something* rather than an empty pointer even if the whole stack is framework code.
+ *
+ * A "frame" here is a single non-empty, non-"Error"-header line from the stack string.
+ *
+ * @private
+ * @param {string} stack
+ * @returns {string} the selected frame trimmed, or empty string when the stack has no frames.
+ */
+function _selectTopFrame(stack) {
+    if (typeof stack !== 'string' || stack.length === 0) {
+        return '';
+    }
+
+    // The first line is usually the message header (`Error: something`) — drop it. Any subsequent
+    // blank line or the header line itself is filtered out below.
+    const lines = stack.split('\n');
+    const frames = [];
+    for (let i = 0; i < lines.length; i++) {
+        const trimmed = lines[i].trim();
+        if (!trimmed) {
+            continue;
+        }
+        // Header line without an `at ` prefix and no obvious location — treat as non-frame.
+        if (i === 0 && trimmed.indexOf('at ') !== 0) {
+            continue;
+        }
+        frames.push(trimmed);
+    }
+
+    if (frames.length === 0) {
+        return '';
+    }
+
+    let skips = 0;
+    for (let i = 0; i < frames.length; i++) {
+        if (skips >= MAX_FRAME_SKIPS || !_isFrameworkFrame(frames[i])) {
+            return frames[i];
+        }
+        skips += 1;
+    }
+
+    // All frames were framework and we exhausted the skip budget — return the last one we saw.
+    return frames[frames.length - 1];
+}
+
+/**
+ * Build the dedup key for an event. `(normalized message, top-shown stack frame)` per the PRD.
+ * @private
+ * @param {string} normalizedMessage
+ * @param {string} frame
+ * @returns {string}
+ */
+function _dedupKey(normalizedMessage, frame) {
+    return normalizedMessage + '\u0000' + frame;
+}
+
+/**
+ * Create a new console-error buffer instance. Each call returns a fresh, independent buffer;
+ * the module exports no shared state.
+ *
+ * @returns {{record: Function, snapshot: Function, clear: Function}}
+ */
+function create() {
+    let entries = [];
+    // Index by dedup key so record() is O(1) on the hot path when errors flood in.
+    let indexByKey = Object.create(null);
+
+    return {
+        /**
+         * Record an event. Shape: `{ type: 'error' | 'warn' | 'uncaught', message, stack? }`.
+         * A duplicate (same dedup key as an existing entry) increments the count on the
+         * existing entry and is *not* promoted to the front. A new distinct entry appends;
+         * once the buffer is at capacity the oldest entry is evicted.
+         *
+         * @param {{type: string, message: string, stack?: string}} event
+         */
+        record: function (event) {
+            if (!event) {
+                return;
+            }
+
+            const normalized = _normalizeMessage(event.message);
+            const frame = _selectTopFrame(event.stack);
+            const key = _dedupKey(normalized, frame);
+
+            if (Object.prototype.hasOwnProperty.call(indexByKey, key)) {
+                indexByKey[key].count += 1;
+                return;
+            }
+
+            const entry = {
+                type: event.type,
+                message: normalized,
+                frame: frame,
+                count: 1
+            };
+
+            entries.push(entry);
+            indexByKey[key] = entry;
+
+            if (entries.length > CAPACITY) {
+                const evicted = entries.shift();
+                // Rebuild the key -> entry index for the surviving entries. Cheap at N = 3.
+                const evictedKey = _dedupKey(evicted.message, evicted.frame);
+                delete indexByKey[evictedKey];
+            }
+        },
+
+        /**
+         * @returns {Array<{type: string, message: string, frame: string, count: number}>}
+         *   A shallow-copied snapshot; mutating it does not affect the internal buffer.
+         */
+        snapshot: function () {
+            return entries.map(function (e) {
+                return {
+                    type: e.type,
+                    message: e.message,
+                    frame: e.frame,
+                    count: e.count
+                };
+            });
+        },
+
+        /**
+         * Empty the buffer. Called by the panel on URL change and Clear Conversation.
+         */
+        clear: function () {
+            entries = [];
+            indexByKey = Object.create(null);
+        }
+    };
+}
+
+module.exports = {
+    create: create
+};

--- a/app/scripts/modules/injected/consoleErrorBuffer.js
+++ b/app/scripts/modules/injected/consoleErrorBuffer.js
@@ -1,8 +1,14 @@
 'use strict';
 
 /**
- * Bounded FIFO of the N most-recent deduplicated console errors and warnings. Duplicates
- * increment `count` on the existing entry and do not re-promote. No browser deps.
+ * Pure state machine over an error-event stream. No browser or Chrome dependencies — the
+ * browser-side glue (attaching listeners, monkey-patching console methods) is a thin adapter
+ * around this module, so the buffer semantics can be unit-tested without a running page.
+ *
+ * The buffer is a bounded FIFO of the three most-recent, deduplicated console errors and
+ * warnings from the inspected page. Recency is defined by *first arrival*: when a new event
+ * hashes to the same key as an existing entry the entry's count increments but the entry does
+ * not move to the front.
  */
 
 const CAPACITY = 3;
@@ -13,7 +19,11 @@ const FRAMEWORK_FRAME_PATTERNS = [
 ];
 
 /**
+ * Normalize a message for dedup-key computation. Collapses runs of whitespace so a message
+ * that differs only in incidental spacing hashes to the same key.
  * @private
+ * @param {string} message
+ * @returns {string}
  */
 function _normalizeMessage(message) {
     if (typeof message !== 'string') {
@@ -23,7 +33,12 @@ function _normalizeMessage(message) {
 }
 
 /**
+ * Test whether a single stack-frame line looks like framework code that the model should not be
+ * pointed at. The heuristics match the paths a UI5 app produces both when loaded from a bootstrap
+ * CDN (`sap-ui-core.js`) and when it references a library file (`resources/sap/...`).
  * @private
+ * @param {string} frame
+ * @returns {boolean}
  */
 function _isFrameworkFrame(frame) {
     for (let i = 0; i < FRAMEWORK_FRAME_PATTERNS.length; i++) {
@@ -35,15 +50,23 @@ function _isFrameworkFrame(frame) {
 }
 
 /**
- * Pick the top non-framework frame. Skips up to `MAX_FRAME_SKIPS` framework frames, then
- * falls back to whichever frame we're on.
+ * Select the top non-framework frame from a stack string. Skips up to `MAX_FRAME_SKIPS`
+ * framework frames total, then falls back to whatever frame we landed on — the model gets
+ * *something* rather than an empty pointer even if the whole stack is framework code.
+ *
+ * A "frame" here is a single non-empty, non-"Error"-header line from the stack string.
+ *
  * @private
+ * @param {string} stack
+ * @returns {string} the selected frame trimmed, or empty string when the stack has no frames.
  */
 function _selectTopFrame(stack) {
     if (typeof stack !== 'string' || stack.length === 0) {
         return '';
     }
 
+    // The first line is usually the message header (`Error: something`) — drop it. Any subsequent
+    // blank line or the header line itself is filtered out below.
     const lines = stack.split('\n');
     const frames = [];
     for (let i = 0; i < lines.length; i++) {
@@ -51,7 +74,7 @@ function _selectTopFrame(stack) {
         if (!trimmed) {
             continue;
         }
-        // Drop the "Error: ..." header line (no `at ` prefix on line 0).
+        // Header line without an `at ` prefix and no obvious location — treat as non-frame.
         if (i === 0 && trimmed.indexOf('at ') !== 0) {
             continue;
         }
@@ -70,25 +93,39 @@ function _selectTopFrame(stack) {
         skips += 1;
     }
 
+    // All frames were framework and we exhausted the skip budget — return the last one we saw.
     return frames[frames.length - 1];
 }
 
 /**
+ * Build the dedup key for an event. `(normalized message, top-shown stack frame)` per the PRD.
  * @private
+ * @param {string} normalizedMessage
+ * @param {string} frame
+ * @returns {string}
  */
 function _dedupKey(normalizedMessage, frame) {
     return normalizedMessage + '\u0000' + frame;
 }
 
 /**
+ * Create a new console-error buffer instance. Each call returns a fresh, independent buffer;
+ * the module exports no shared state.
+ *
  * @returns {{record: Function, snapshot: Function, clear: Function}}
  */
 function create() {
     let entries = [];
+    // Index by dedup key so record() is O(1) on the hot path when errors flood in.
     let indexByKey = Object.create(null);
 
     return {
         /**
+         * Record an event. Shape: `{ type: 'error' | 'warn' | 'uncaught', message, stack? }`.
+         * A duplicate (same dedup key as an existing entry) increments the count on the
+         * existing entry and is *not* promoted to the front. A new distinct entry appends;
+         * once the buffer is at capacity the oldest entry is evicted.
+         *
          * @param {{type: string, message: string, stack?: string}} event
          */
         record: function (event) {
@@ -117,6 +154,7 @@ function create() {
 
             if (entries.length > CAPACITY) {
                 const evicted = entries.shift();
+                // Rebuild the key -> entry index for the surviving entries. Cheap at N = 3.
                 const evictedKey = _dedupKey(evicted.message, evicted.frame);
                 delete indexByKey[evictedKey];
             }
@@ -124,6 +162,7 @@ function create() {
 
         /**
          * @returns {Array<{type: string, message: string, frame: string, count: number}>}
+         *   A shallow-copied snapshot; mutating it does not affect the internal buffer.
          */
         snapshot: function () {
             return entries.map(function (e) {
@@ -136,6 +175,9 @@ function create() {
             });
         },
 
+        /**
+         * Empty the buffer. Called by the panel on URL change and Clear Conversation.
+         */
         clear: function () {
             entries = [];
             indexByKey = Object.create(null);

--- a/app/scripts/modules/injected/consoleErrorCapture.js
+++ b/app/scripts/modules/injected/consoleErrorCapture.js
@@ -3,13 +3,18 @@
 const consoleErrorBuffer = require('./consoleErrorBuffer.js');
 
 /**
- * Wraps `console.error`/`console.warn` and hooks `window.onerror` and `unhandledrejection`,
- * feeding every event into a {@link consoleErrorBuffer}. Idempotent — repeated calls return
- * the same handle.
+ * Browser-side glue around {@link consoleErrorBuffer}. Monkey-patches `console.error` and
+ * `console.warn` and subscribes to `window.onerror` and `unhandledrejection`, funneling every
+ * error-like event into the buffer's state machine.
  *
- * @param {Window} win - The inspected page's window.
+ * The original `console.error` / `console.warn` continue to run, so the developer's own console
+ * output is not silenced by the capture. Wrap once — repeated calls to {@link install} are a
+ * no-op.
+ *
+ * @param {Window} win - Injection target (the inspected page's window). Injected in tests.
  * @param {Object} [options]
- * @param {Function} [options.onRecord] - Called after every recorded event.
+ * @param {Function} [options.onRecord] - Called after every recorded event. Used by the injected
+ *     glue to push a fresh snapshot to the panel.
  * @returns {{buffer: Object, uninstall: Function}}
  */
 function install(win, options) {
@@ -23,12 +28,15 @@ function install(win, options) {
             try {
                 onRecord();
             } catch (e) {
-                // Don't let a subscriber break capture.
+                // Never let a subscriber failure disrupt the capture.
             }
         }
     }
 
-    // Install once — the injected script can re-run after `do-script-injection`.
+    // Install-once guard. Stashed on the inspected page's `window` — a foreign object we do not
+    // own — because the injected script may be re-injected after `do-script-injection` and we
+    // must not stack patches on top of patches. Namespaced with `__ui5Inspector` to signal that
+    // this key belongs to this extension and is not intended for the page's own code.
     if (win.__ui5InspectorConsoleErrorCaptureInstalled) {
         return win.__ui5InspectorConsoleErrorCaptureInstalled;
     }
@@ -38,6 +46,9 @@ function install(win, options) {
     const originalOnError = win.onerror;
     const originalOnUnhandled = win.onunhandledrejection;
 
+    // Stringify console.error / console.warn arguments the way Node/Chrome would when you
+    // paste them into console: values separated by spaces, objects JSON-stringified. Kept
+    // deliberately simple — the model just needs the message text, not perfect fidelity.
     function _joinArgs(args) {
         return Array.prototype.map.call(args, function (arg) {
             if (arg === null) { return 'null'; }
@@ -71,7 +82,7 @@ function install(win, options) {
                 stack: _extractStack(arguments)
             });
         } catch (e) {
-            // Don't break the page's own console.error.
+            // Never let capture failure disrupt the developer's own console.error output.
         }
         if (typeof originalError === 'function') {
             return originalError.apply(win.console, arguments);
@@ -94,8 +105,8 @@ function install(win, options) {
     };
 
     win.onerror = function () {
-        // Signature (message, source, lineno, colno, error) — 5 params > JSHint maxparams,
-        // so read from `arguments`.
+        // Signature: (message, source, lineno, colno, error) — five params exceed the repo's
+        // JSHint `maxparams` cap, so we read them off `arguments` instead.
         const message = arguments[0];
         const source = arguments[1];
         const lineno = arguments[2];

--- a/app/scripts/modules/injected/consoleErrorCapture.js
+++ b/app/scripts/modules/injected/consoleErrorCapture.js
@@ -3,18 +3,13 @@
 const consoleErrorBuffer = require('./consoleErrorBuffer.js');
 
 /**
- * Browser-side glue around {@link consoleErrorBuffer}. Monkey-patches `console.error` and
- * `console.warn` and subscribes to `window.onerror` and `unhandledrejection`, funneling every
- * error-like event into the buffer's state machine.
+ * Browser-side glue around {@link consoleErrorBuffer}. Wraps `console.error`/`console.warn`
+ * and subscribes to `window.onerror` / `unhandledrejection`, funneling every event into the
+ * buffer. Idempotent — repeated calls return the same handle.
  *
- * The original `console.error` / `console.warn` continue to run, so the developer's own console
- * output is not silenced by the capture. Wrap once — repeated calls to {@link install} are a
- * no-op.
- *
- * @param {Window} win - Injection target (the inspected page's window). Injected in tests.
+ * @param {Window} win - Injection target (the inspected page's window).
  * @param {Object} [options]
- * @param {Function} [options.onRecord] - Called after every recorded event. Used by the injected
- *     glue to push a fresh snapshot to the panel.
+ * @param {Function} [options.onRecord] - Called after every recorded event.
  * @returns {{buffer: Object, uninstall: Function}}
  */
 function install(win, options) {
@@ -28,15 +23,12 @@ function install(win, options) {
             try {
                 onRecord();
             } catch (e) {
-                // Never let a subscriber failure disrupt the capture.
+                // Subscriber failure must not break capture.
             }
         }
     }
 
-    // Install-once guard. Stashed on the inspected page's `window` — a foreign object we do not
-    // own — because the injected script may be re-injected after `do-script-injection` and we
-    // must not stack patches on top of patches. Namespaced with `__ui5Inspector` to signal that
-    // this key belongs to this extension and is not intended for the page's own code.
+    // Install-once guard: the injected script may re-run after `do-script-injection`.
     if (win.__ui5InspectorConsoleErrorCaptureInstalled) {
         return win.__ui5InspectorConsoleErrorCaptureInstalled;
     }
@@ -46,9 +38,6 @@ function install(win, options) {
     const originalOnError = win.onerror;
     const originalOnUnhandled = win.onunhandledrejection;
 
-    // Stringify console.error / console.warn arguments the way Node/Chrome would when you
-    // paste them into console: values separated by spaces, objects JSON-stringified. Kept
-    // deliberately simple — the model just needs the message text, not perfect fidelity.
     function _joinArgs(args) {
         return Array.prototype.map.call(args, function (arg) {
             if (arg === null) { return 'null'; }
@@ -82,7 +71,7 @@ function install(win, options) {
                 stack: _extractStack(arguments)
             });
         } catch (e) {
-            // Never let capture failure disrupt the developer's own console.error output.
+            // Capture failure must not break the developer's own console output.
         }
         if (typeof originalError === 'function') {
             return originalError.apply(win.console, arguments);
@@ -105,8 +94,8 @@ function install(win, options) {
     };
 
     win.onerror = function () {
-        // Signature: (message, source, lineno, colno, error) — five params exceed the repo's
-        // JSHint `maxparams` cap, so we read them off `arguments` instead.
+        // Read positional args off `arguments`: (message, source, lineno, colno, error)
+        // exceeds JSHint's `maxparams` cap.
         const message = arguments[0];
         const source = arguments[1];
         const lineno = arguments[2];

--- a/app/scripts/modules/injected/consoleErrorCapture.js
+++ b/app/scripts/modules/injected/consoleErrorCapture.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const consoleErrorBuffer = require('./consoleErrorBuffer.js');
+
+/**
+ * Browser-side glue around {@link consoleErrorBuffer}. Monkey-patches `console.error` and
+ * `console.warn` and subscribes to `window.onerror` and `unhandledrejection`, funneling every
+ * error-like event into the buffer's state machine.
+ *
+ * The original `console.error` / `console.warn` continue to run, so the developer's own console
+ * output is not silenced by the capture. Wrap once — repeated calls to {@link install} are a
+ * no-op.
+ *
+ * @param {Window} win - Injection target (the inspected page's window). Injected in tests.
+ * @param {Object} [options]
+ * @param {Function} [options.onRecord] - Called after every recorded event. Used by the injected
+ *     glue to push a fresh snapshot to the panel.
+ * @returns {{buffer: Object, uninstall: Function}}
+ */
+function install(win, options) {
+    options = options || {};
+    const onRecord = typeof options.onRecord === 'function' ? options.onRecord : null;
+    const buffer = consoleErrorBuffer.create();
+
+    function _record(event) {
+        buffer.record(event);
+        if (onRecord) {
+            try {
+                onRecord();
+            } catch (e) {
+                // Never let a subscriber failure disrupt the capture.
+            }
+        }
+    }
+
+    // Install-once guard. Stashed on the inspected page's `window` — a foreign object we do not
+    // own — because the injected script may be re-injected after `do-script-injection` and we
+    // must not stack patches on top of patches. Namespaced with `__ui5Inspector` to signal that
+    // this key belongs to this extension and is not intended for the page's own code.
+    if (win.__ui5InspectorConsoleErrorCaptureInstalled) {
+        return win.__ui5InspectorConsoleErrorCaptureInstalled;
+    }
+
+    const originalError = win.console && win.console.error;
+    const originalWarn = win.console && win.console.warn;
+    const originalOnError = win.onerror;
+    const originalOnUnhandled = win.onunhandledrejection;
+
+    // Stringify console.error / console.warn arguments the way Node/Chrome would when you
+    // paste them into console: values separated by spaces, objects JSON-stringified. Kept
+    // deliberately simple — the model just needs the message text, not perfect fidelity.
+    function _joinArgs(args) {
+        return Array.prototype.map.call(args, function (arg) {
+            if (arg === null) { return 'null'; }
+            if (typeof arg === 'undefined') { return 'undefined'; }
+            if (typeof arg === 'string') { return arg; }
+            if (arg instanceof Error) {
+                return arg.stack || (arg.name + ': ' + arg.message);
+            }
+            try {
+                return JSON.stringify(arg);
+            } catch (e) {
+                return String(arg);
+            }
+        }).join(' ');
+    }
+
+    function _extractStack(args) {
+        for (let i = 0; i < args.length; i++) {
+            if (args[i] instanceof Error && args[i].stack) {
+                return args[i].stack;
+            }
+        }
+        return undefined;
+    }
+
+    win.console.error = function () {
+        try {
+            _record({
+                type: 'error',
+                message: _joinArgs(arguments),
+                stack: _extractStack(arguments)
+            });
+        } catch (e) {
+            // Never let capture failure disrupt the developer's own console.error output.
+        }
+        if (typeof originalError === 'function') {
+            return originalError.apply(win.console, arguments);
+        }
+    };
+
+    win.console.warn = function () {
+        try {
+            _record({
+                type: 'warn',
+                message: _joinArgs(arguments),
+                stack: _extractStack(arguments)
+            });
+        } catch (e) {
+            // See above.
+        }
+        if (typeof originalWarn === 'function') {
+            return originalWarn.apply(win.console, arguments);
+        }
+    };
+
+    win.onerror = function () {
+        // Signature: (message, source, lineno, colno, error) — five params exceed the repo's
+        // JSHint `maxparams` cap, so we read them off `arguments` instead.
+        const message = arguments[0];
+        const source = arguments[1];
+        const lineno = arguments[2];
+        const colno = arguments[3];
+        const error = arguments[4];
+        try {
+            _record({
+                type: 'uncaught',
+                message: typeof message === 'string' ? message : String(message),
+                stack: error && error.stack ? error.stack :
+                    (source ? '    at ' + source + ':' + (lineno || 0) + ':' + (colno || 0) : undefined)
+            });
+        } catch (e) {
+            // See above.
+        }
+        if (typeof originalOnError === 'function') {
+            return originalOnError.apply(win, arguments);
+        }
+        return false;
+    };
+
+    win.onunhandledrejection = function (event) {
+        try {
+            const reason = event && event.reason;
+            let message;
+            let stack;
+            if (reason instanceof Error) {
+                message = reason.message || String(reason);
+                stack = reason.stack;
+            } else if (typeof reason === 'string') {
+                message = reason;
+            } else {
+                try {
+                    message = JSON.stringify(reason);
+                } catch (e) {
+                    message = String(reason);
+                }
+            }
+            _record({
+                type: 'uncaught',
+                message: 'Unhandled promise rejection: ' + message,
+                stack: stack
+            });
+        } catch (e) {
+            // See above.
+        }
+        if (typeof originalOnUnhandled === 'function') {
+            return originalOnUnhandled.apply(win, arguments);
+        }
+    };
+
+    const handle = {
+        buffer: buffer,
+        uninstall: function () {
+            win.console.error = originalError;
+            win.console.warn = originalWarn;
+            win.onerror = originalOnError;
+            win.onunhandledrejection = originalOnUnhandled;
+            delete win.__ui5InspectorConsoleErrorCaptureInstalled;
+        }
+    };
+    win.__ui5InspectorConsoleErrorCaptureInstalled = handle;
+    return handle;
+}
+
+module.exports = {
+    install: install
+};

--- a/app/scripts/modules/injected/consoleErrorCapture.js
+++ b/app/scripts/modules/injected/consoleErrorCapture.js
@@ -3,18 +3,13 @@
 const consoleErrorBuffer = require('./consoleErrorBuffer.js');
 
 /**
- * Browser-side glue around {@link consoleErrorBuffer}. Monkey-patches `console.error` and
- * `console.warn` and subscribes to `window.onerror` and `unhandledrejection`, funneling every
- * error-like event into the buffer's state machine.
+ * Wraps `console.error`/`console.warn` and hooks `window.onerror` and `unhandledrejection`,
+ * feeding every event into a {@link consoleErrorBuffer}. Idempotent — repeated calls return
+ * the same handle.
  *
- * The original `console.error` / `console.warn` continue to run, so the developer's own console
- * output is not silenced by the capture. Wrap once — repeated calls to {@link install} are a
- * no-op.
- *
- * @param {Window} win - Injection target (the inspected page's window). Injected in tests.
+ * @param {Window} win - The inspected page's window.
  * @param {Object} [options]
- * @param {Function} [options.onRecord] - Called after every recorded event. Used by the injected
- *     glue to push a fresh snapshot to the panel.
+ * @param {Function} [options.onRecord] - Called after every recorded event.
  * @returns {{buffer: Object, uninstall: Function}}
  */
 function install(win, options) {
@@ -28,15 +23,12 @@ function install(win, options) {
             try {
                 onRecord();
             } catch (e) {
-                // Never let a subscriber failure disrupt the capture.
+                // Don't let a subscriber break capture.
             }
         }
     }
 
-    // Install-once guard. Stashed on the inspected page's `window` — a foreign object we do not
-    // own — because the injected script may be re-injected after `do-script-injection` and we
-    // must not stack patches on top of patches. Namespaced with `__ui5Inspector` to signal that
-    // this key belongs to this extension and is not intended for the page's own code.
+    // Install once — the injected script can re-run after `do-script-injection`.
     if (win.__ui5InspectorConsoleErrorCaptureInstalled) {
         return win.__ui5InspectorConsoleErrorCaptureInstalled;
     }
@@ -46,9 +38,6 @@ function install(win, options) {
     const originalOnError = win.onerror;
     const originalOnUnhandled = win.onunhandledrejection;
 
-    // Stringify console.error / console.warn arguments the way Node/Chrome would when you
-    // paste them into console: values separated by spaces, objects JSON-stringified. Kept
-    // deliberately simple — the model just needs the message text, not perfect fidelity.
     function _joinArgs(args) {
         return Array.prototype.map.call(args, function (arg) {
             if (arg === null) { return 'null'; }
@@ -82,7 +71,7 @@ function install(win, options) {
                 stack: _extractStack(arguments)
             });
         } catch (e) {
-            // Never let capture failure disrupt the developer's own console.error output.
+            // Don't break the page's own console.error.
         }
         if (typeof originalError === 'function') {
             return originalError.apply(win.console, arguments);
@@ -105,8 +94,8 @@ function install(win, options) {
     };
 
     win.onerror = function () {
-        // Signature: (message, source, lineno, colno, error) — five params exceed the repo's
-        // JSHint `maxparams` cap, so we read them off `arguments` instead.
+        // Signature (message, source, lineno, colno, error) — 5 params > JSHint maxparams,
+        // so read from `arguments`.
         const message = arguments[0];
         const source = arguments[1];
         const lineno = arguments[2];

--- a/app/scripts/modules/injected/consoleErrorCapture.js
+++ b/app/scripts/modules/injected/consoleErrorCapture.js
@@ -3,11 +3,11 @@
 const consoleErrorBuffer = require('./consoleErrorBuffer.js');
 
 /**
- * Browser-side glue around {@link consoleErrorBuffer}. Wraps `console.error`/`console.warn`
- * and subscribes to `window.onerror` / `unhandledrejection`, funneling every event into the
- * buffer. Idempotent — repeated calls return the same handle.
+ * Wraps `console.error`/`console.warn` and hooks `window.onerror` and `unhandledrejection`,
+ * feeding every event into a {@link consoleErrorBuffer}. Idempotent — repeated calls return
+ * the same handle.
  *
- * @param {Window} win - Injection target (the inspected page's window).
+ * @param {Window} win - The inspected page's window.
  * @param {Object} [options]
  * @param {Function} [options.onRecord] - Called after every recorded event.
  * @returns {{buffer: Object, uninstall: Function}}
@@ -23,12 +23,12 @@ function install(win, options) {
             try {
                 onRecord();
             } catch (e) {
-                // Subscriber failure must not break capture.
+                // Don't let a subscriber break capture.
             }
         }
     }
 
-    // Install-once guard: the injected script may re-run after `do-script-injection`.
+    // Install once — the injected script can re-run after `do-script-injection`.
     if (win.__ui5InspectorConsoleErrorCaptureInstalled) {
         return win.__ui5InspectorConsoleErrorCaptureInstalled;
     }
@@ -71,7 +71,7 @@ function install(win, options) {
                 stack: _extractStack(arguments)
             });
         } catch (e) {
-            // Capture failure must not break the developer's own console output.
+            // Don't break the page's own console.error.
         }
         if (typeof originalError === 'function') {
             return originalError.apply(win.console, arguments);
@@ -94,8 +94,8 @@ function install(win, options) {
     };
 
     win.onerror = function () {
-        // Read positional args off `arguments`: (message, source, lineno, colno, error)
-        // exceeds JSHint's `maxparams` cap.
+        // Signature (message, source, lineno, colno, error) — 5 params > JSHint maxparams,
+        // so read from `arguments`.
         const message = arguments[0];
         const source = arguments[1];
         const lineno = arguments[2];

--- a/app/scripts/modules/ui/AIChat.js
+++ b/app/scripts/modules/ui/AIChat.js
@@ -15,6 +15,11 @@ const AssistantTranscript = require('../ai/AssistantTranscript.js');
  * @param {string} containerId
  * @param {Object} [options]
  * @param {Function} [options.getAppInfo] - Returns the UI5 metadata snapshot for PromptBuilder.
+ * @param {Function} [options.getConsoleErrors] - Returns the recent-console-errors snapshot
+ *     captured from the inspected page. Forwarded to the controller so it reaches
+ *     {@link PromptBuilder#buildUserPrompt} on each send.
+ * @param {Function} [options.clearConsoleErrors] - Clears the recent-console-errors buffer for the
+ *     current URL. Called by the controller on Clear Conversation and URL change.
  * @param {AssistantController} [options.controller] - Pre-built controller for tests. Defaults to a
  *                                                     fresh AssistantController.
  * @param {Function} [options.transcriptFactory] - Test seam: `(container, options) => AssistantTranscript`.
@@ -24,6 +29,8 @@ const AssistantTranscript = require('../ai/AssistantTranscript.js');
  */
 function AIChat(containerId, {
     getAppInfo = null,
+    getConsoleErrors = null,
+    clearConsoleErrors = null,
     controller = null,
     transcriptFactory = function (host, options) {
         return new AssistantTranscript(host, options);
@@ -32,8 +39,12 @@ function AIChat(containerId, {
     this._container = document.getElementById(containerId);
 
     this._getAppInfo = getAppInfo;
+    this._getConsoleErrors = getConsoleErrors;
+    this._clearConsoleErrors = clearConsoleErrors;
     this._controller = controller || new AssistantController({
-        getAppInfo: this._getAppInfo || function () { return null; }
+        getAppInfo: this._getAppInfo || function () { return null; },
+        getConsoleErrors: this._getConsoleErrors || function () { return []; },
+        clearConsoleErrors: this._clearConsoleErrors || function () {}
     });
     this._transcriptFactory = transcriptFactory;
 

--- a/tests/modules/ai/AssistantController.spec.js
+++ b/tests/modules/ai/AssistantController.spec.js
@@ -578,9 +578,9 @@ describe('AssistantController', function () {
                 }).then(function () {
                     harness.promptClient.userPromptsByCall.should.have.length(2);
                     harness.promptClient.userPromptsByCall[0].should.contain('Type: sap.m.Button');
-                    harness.promptClient.userPromptsByCall[0].should.contain('User Question: Explain this');
+                    harness.promptClient.userPromptsByCall[0].should.contain('Now answer: Explain this');
                     harness.promptClient.userPromptsByCall[1].should.contain('Type: sap.m.Button');
-                    harness.promptClient.userPromptsByCall[1].should.contain('User Question: And now?');
+                    harness.promptClient.userPromptsByCall[1].should.contain('Now answer: And now?');
                 });
             });
         });
@@ -718,7 +718,7 @@ describe('AssistantController', function () {
                 }).then(function () {
                     harness.promptClient.userPromptsByCall.should.have.length(1);
                     harness.promptClient.userPromptsByCall[0].should.contain('Type: sap.m.Button');
-                    harness.promptClient.userPromptsByCall[0].should.contain('User Question: After clear');
+                    harness.promptClient.userPromptsByCall[0].should.contain('Now answer: After clear');
                 });
             });
         });

--- a/tests/modules/ai/AssistantController.spec.js
+++ b/tests/modules/ai/AssistantController.spec.js
@@ -17,6 +17,10 @@ function createFakePromptClient() {
         usageInfo: null,
         downloadShouldFail: false,
         downloadProgressValues: [],
+        // Test-controllable return value for hasActiveSession(). Defaults to true — the
+        // Prompt Client normally has a live session while the panel is open. Tests flip this
+        // to false to simulate Chrome having killed the idle background service worker.
+        hasActiveSessionResult: true,
 
         seedMessagesByCall: [],
         userPromptsByCall: [],
@@ -28,6 +32,10 @@ function createFakePromptClient() {
 
         checkAvailability: function () {
             return Promise.resolve(fake.availabilityResult);
+        },
+
+        hasActiveSession: function () {
+            return fake.hasActiveSessionResult;
         },
 
         downloadModel: function (onProgress) {
@@ -1279,6 +1287,171 @@ describe('AssistantController', function () {
                     });
                 }).then(function () {
                     harness.promptClient.userPromptsByCall.should.deep.equal(['after url change']);
+                });
+            });
+        });
+    });
+
+    describe('#sendUserMessage() — idle-killed session recovery', function () {
+        it('should reseed the session before streaming when the Prompt Client reports no active session, so the Send after Chrome kills the idle background service worker does not surface as a streaming-failed banner', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                // Arrange: simulate Chrome having torn down the idle background service worker.
+                // The Prompt Client's `onDisconnect` handler already flipped `_hasActiveSession`
+                // to false on the real client; the fake exposes the same signal.
+                harness.promptClient.hasActiveSessionResult = false;
+                const seedCallsBeforeSend = harness.promptClient.seedMessagesByCall.length;
+
+                const sendPromise = harness.controller.sendUserMessage('after idle');
+
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    // A recovery reseed must have fired before promptStreaming.
+                    harness.promptClient.seedMessagesByCall.length.should.equal(seedCallsBeforeSend + 1);
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                }).then(function () {
+                    harness.promptClient.userPromptsByCall.should.deep.equal(['after idle']);
+                    const completeEvents = harness.events.filter(function (e) {
+                        return e.type === 'stream-complete';
+                    });
+                    completeEvents.should.have.length(1);
+                });
+            });
+        });
+
+        it('should carry the current Conversation Memory into the idle-recovery reseed so follow-up questions after Chrome kills the idle session still reference earlier turns', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                // Establish prior turns with a normal Send.
+                const firstSend = harness.controller.sendUserMessage('first question');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('first answer');
+                    streamCtrl.emitComplete();
+                    return firstSend;
+                });
+            }).then(function () {
+                // Idle window: session dies.
+                harness.promptClient.hasActiveSessionResult = false;
+                const seedCallsBeforeSend = harness.promptClient.seedMessagesByCall.length;
+
+                const followUp = harness.controller.sendUserMessage('follow-up');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    const reseedSeed = harness.promptClient.seedMessagesByCall[seedCallsBeforeSend];
+                    // The recovery reseed's seed messages must contain the earlier user + assistant turns.
+                    const roles = reseedSeed.map(function (m) { return m.role; });
+                    roles.should.deep.equal(['system', 'user', 'assistant']);
+                    reseedSeed[1].should.deep.equal({ role: 'user', content: 'first question' });
+                    reseedSeed[2].should.deep.equal({ role: 'assistant', content: 'first answer' });
+
+                    streamCtrl.emitChunk('follow-up answer');
+                    streamCtrl.emitComplete();
+                    return followUp;
+                });
+            });
+        });
+
+        it('should not trigger a second reseed when a clearConversation reseed is already in flight and Send arrives with no active session, so exactly one createSession fires and the two paths do not race', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                // Defer the reseed createSession so the reseed window from clearConversation stays open.
+                harness.promptClient.deferredCreateSession = createDeferred();
+                const seedCallsBeforeClear = harness.promptClient.seedMessagesByCall.length;
+
+                harness.controller.clearConversation();
+                // Simulate the background session being dead at this moment too — Send must
+                // NOT kick off a second reseed on top of the in-flight one.
+                harness.promptClient.hasActiveSessionResult = false;
+                const sendPromise = harness.controller.sendUserMessage('during clear');
+
+                return new Promise(function (resolve) { setTimeout(resolve, 0); }).then(function () {
+                    // Exactly one createSession call fired between clearConversation and Send.
+                    harness.promptClient.seedMessagesByCall.length.should.equal(seedCallsBeforeClear + 1);
+                    harness.promptClient.userPromptsByCall.should.have.length(0);
+
+                    // Resolve the deferred reseed — Send should now proceed on that same session.
+                    harness.promptClient.deferredCreateSession.resolve(true);
+                    // The reseed just succeeded; from here on the fake reports an active session again.
+                    harness.promptClient.hasActiveSessionResult = true;
+
+                    return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                        // Still exactly one createSession call across the whole scenario.
+                        harness.promptClient.seedMessagesByCall.length.should.equal(seedCallsBeforeClear + 1);
+                        streamCtrl.emitChunk('ok');
+                        streamCtrl.emitComplete();
+                        return sendPromise;
+                    });
+                }).then(function () {
+                    harness.promptClient.userPromptsByCall.should.deep.equal(['during clear']);
+                });
+            });
+        });
+
+        it('should reject sendUserMessage with the seed error and leave the Assistant Capability State at session-failed when the idle-recovery reseed itself fails, instead of overwriting it with streaming-failed', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                harness.promptClient.hasActiveSessionResult = false;
+                harness.promptClient.createSessionError = new Error('idle recovery reseed failed');
+
+                return harness.controller.sendUserMessage('after idle').then(function () {
+                    throw new Error('Expected sendUserMessage to reject when the idle-recovery reseed failed');
+                }, function (err) {
+                    err.message.should.contain('idle recovery reseed failed');
+                }).then(function () {
+                    harness.controller._capabilityState.status.should.equal('session-failed');
+                    const streamingFailedStates = harness.capabilityStates.filter(function (s) {
+                        return s.status === 'streaming-failed';
+                    });
+                    streamingFailedStates.should.have.length(0);
+                    harness.promptClient.userPromptsByCall.should.have.length(0);
+                });
+            });
+        });
+
+        it('should not trigger any extra createSession on Send when the Prompt Client reports an active session, so the alive path stays byte-identical to today', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                // Default is hasActiveSessionResult === true. The initialize() reseed already ran.
+                const seedCallsAfterInit = harness.promptClient.seedMessagesByCall.length;
+                seedCallsAfterInit.should.equal(1);
+
+                const sendPromise = harness.controller.sendUserMessage('normal send');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    // No idle-recovery reseed fired: seed count unchanged since init.
+                    harness.promptClient.seedMessagesByCall.length.should.equal(seedCallsAfterInit);
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                }).then(function () {
+                    harness.promptClient.seedMessagesByCall.length.should.equal(seedCallsAfterInit);
+                    harness.promptClient.userPromptsByCall.should.deep.equal(['normal send']);
+                });
+            });
+        });
+
+        it('should still inject the attached Inspection Context into the formatted user prompt after an idle-recovery reseed, so pressing Send after coming back does not silently drop the selected control', function () {
+            const harness = createController();
+
+            return initializedReady(harness).then(function () {
+                harness.controller.updateInspectionContext({
+                    control: { id: '__button0', type: 'sap.m.Button', properties: { text: 'Save' } }
+                });
+                harness.promptClient.hasActiveSessionResult = false;
+
+                const sendPromise = harness.controller.sendUserMessage('what does it do?');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                }).then(function () {
+                    harness.promptClient.userPromptsByCall.should.have.length(1);
+                    const formatted = harness.promptClient.userPromptsByCall[0];
+                    formatted.should.contain('sap.m.Button');
                 });
             });
         });

--- a/tests/modules/ai/AssistantController.spec.js
+++ b/tests/modules/ai/AssistantController.spec.js
@@ -151,12 +151,16 @@ function createController(overrides) {
     const conversationStore = overrides.conversationStore || createFakeConversationStore();
     const promptBuilder = overrides.promptBuilder || new PromptBuilder();
     const getAppInfo = overrides.getAppInfo || function () { return null; };
+    const getConsoleErrors = overrides.getConsoleErrors || function () { return []; };
+    const clearConsoleErrors = overrides.clearConsoleErrors || function () {};
 
     const controller = new AssistantController({
         promptBuilder: promptBuilder,
         promptClient: promptClient,
         conversationStore: conversationStore,
-        getAppInfo: getAppInfo
+        getAppInfo: getAppInfo,
+        getConsoleErrors: getConsoleErrors,
+        clearConsoleErrors: clearConsoleErrors
     });
 
     const events = [];
@@ -690,6 +694,169 @@ describe('AssistantController', function () {
                     harness.promptClient.userPromptsByCall[0].should.contain('Type: sap.m.Input');
                     harness.promptClient.userPromptsByCall[0].should.not.contain('Type: sap.m.Button');
                 });
+            });
+        });
+    });
+
+    describe('#sendUserMessage() — Recent Console Errors seam', function () {
+        it('should invoke getConsoleErrors once per send and forward the snapshot to Prompt Builder as the third argument', function () {
+            const calls = [];
+            const snapshot = [
+                { type: 'error', message: 'boom', frame: 'app.js:1', count: 1 }
+            ];
+            const harness = createController({
+                getConsoleErrors: function () {
+                    calls.push('called');
+                    return snapshot;
+                }
+            });
+
+            return initializedReady(harness).then(function () {
+                const sendPromise = harness.controller.sendUserMessage('Explain');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                });
+            }).then(function () {
+                calls.should.have.length(1);
+                harness.promptClient.userPromptsByCall[0].should.contain('Recent Console Errors:');
+                harness.promptClient.userPromptsByCall[0].should.contain('- boom');
+            });
+        });
+
+        it('should not include the Recent Console Errors section when getConsoleErrors returns an empty array', function () {
+            const harness = createController({
+                getConsoleErrors: function () { return []; }
+            });
+
+            return initializedReady(harness).then(function () {
+                const sendPromise = harness.controller.sendUserMessage('Q');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                });
+            }).then(function () {
+                harness.promptClient.userPromptsByCall[0].should.not.contain('Recent Console Errors');
+            });
+        });
+
+        it('should fall back to no-errors when getConsoleErrors returns undefined instead of an array', function () {
+            const harness = createController({
+                getConsoleErrors: function () { return undefined; }
+            });
+
+            return initializedReady(harness).then(function () {
+                const sendPromise = harness.controller.sendUserMessage('Q');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                });
+            }).then(function () {
+                harness.promptClient.userPromptsByCall[0].should.equal('Q');
+            });
+        });
+
+        it('should fall back to no-errors when getConsoleErrors throws, so a broken panel wiring does not break the send flow', function () {
+            const harness = createController({
+                getConsoleErrors: function () { throw new Error('panel wiring broken'); }
+            });
+
+            return initializedReady(harness).then(function () {
+                const sendPromise = harness.controller.sendUserMessage('Q');
+                return awaitStreamController(harness.promptClient).then(function (streamCtrl) {
+                    streamCtrl.emitChunk('ok');
+                    streamCtrl.emitComplete();
+                    return sendPromise;
+                });
+            }).then(function () {
+                harness.promptClient.userPromptsByCall[0].should.equal('Q');
+            });
+        });
+
+        it('should treat a missing getConsoleErrors option as an empty snapshot (backwards-compat with existing constructor callers)', function () {
+            const controller = new AssistantController({
+                promptBuilder: new PromptBuilder(),
+                promptClient: createFakePromptClient(),
+                conversationStore: createFakeConversationStore()
+                // no getConsoleErrors — the default should be safe.
+            });
+            controller._capabilityState = { status: 'ready', message: '', progress: 0 };
+            controller._currentUrl = 'https://example.com';
+
+            // The critical invariant: reading _safeGetConsoleErrors should not throw.
+            controller._safeGetConsoleErrors().should.deep.equal([]);
+        });
+    });
+
+    describe('#clearConversation() — Recent Console Errors buffer', function () {
+        it('should invoke clearConsoleErrors alongside conversation-store clear so the buffer resets in lock-step with Conversation Memory', function () {
+            let clearCalls = 0;
+            const harness = createController({
+                clearConsoleErrors: function () { clearCalls += 1; }
+            });
+
+            return initializedReady(harness).then(function () {
+                clearCalls = 0; // ignore any clears fired during initialize()/setUrl()
+                return harness.controller.clearConversation();
+            }).then(function () {
+                clearCalls.should.equal(1);
+            });
+        });
+
+        it('should not throw when clearConsoleErrors itself throws — a broken panel wiring must not block Clear Conversation', function () {
+            const harness = createController({
+                clearConsoleErrors: function () { throw new Error('panel wiring broken'); }
+            });
+
+            return initializedReady(harness).then(function () {
+                return harness.controller.clearConversation();
+            }).then(function () {
+                harness.controller._capabilityState.status.should.equal('ready');
+            });
+        });
+    });
+
+    describe('#setUrl() — Recent Console Errors buffer', function () {
+        it('should invoke clearConsoleErrors when the URL changes so buffered errors from the previous page do not leak into the new debugging session', function () {
+            let clearCalls = 0;
+            const harness = createController({
+                clearConsoleErrors: function () { clearCalls += 1; }
+            });
+
+            return initializedReady(harness).then(function () {
+                clearCalls = 0; // ignore any clears during initialize()
+                return harness.controller.setUrl('https://other.example.com');
+            }).then(function () {
+                clearCalls.should.equal(1);
+            });
+        });
+
+        it('should not invoke clearConsoleErrors when setUrl is called with the same URL (the dedupe path)', function () {
+            let clearCalls = 0;
+            const harness = createController({
+                clearConsoleErrors: function () { clearCalls += 1; }
+            });
+
+            return initializedReady(harness).then(function () {
+                clearCalls = 0;
+                return harness.controller.setUrl('https://example.com');
+            }).then(function () {
+                clearCalls.should.equal(0);
+            });
+        });
+
+        it('should not throw when clearConsoleErrors itself throws — a broken panel wiring must not block a URL change', function () {
+            const harness = createController({
+                clearConsoleErrors: function () { throw new Error('panel wiring broken'); }
+            });
+
+            return initializedReady(harness).then(function () {
+                return harness.controller.setUrl('https://other.example.com');
+            }).then(function () {
+                harness.controller._currentUrl.should.equal('https://other.example.com');
             });
         });
     });

--- a/tests/modules/ai/PromptBuilder.spec.js
+++ b/tests/modules/ai/PromptBuilder.spec.js
@@ -14,56 +14,383 @@ describe('PromptBuilder', function () {
     });
 
     describe('#buildSystemPrompt()', function () {
-        it('should return the base UI5 assistant prompt without application metadata when no app info is provided', function () {
-            const prompt = promptBuilder.buildSystemPrompt();
 
-            prompt.should.contain('AI assistant');
-            prompt.should.contain('UI5 Inspector');
-            prompt.should.not.contain('Current Application Context');
+        describe('base prompt (no app info)', function () {
+            it('should return a prompt with Role, Rules, and Style zones and no Current Application Context section', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                prompt.should.contain('Role:');
+                prompt.should.contain('Rules:');
+                prompt.should.contain('Style:');
+                prompt.should.not.contain('Current Application Context');
+            });
+
+            it('should describe the assistant as embedded in the UI5 Inspector and specialized in UI5, OpenUI5, and UI5 Web Components', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                prompt.should.contain('UI5 Inspector');
+                prompt.should.contain('UI5, OpenUI5');
+                prompt.should.contain('UI5 Web Components');
+            });
+
+            it('should place the Role zone before the Rules zone and the Rules zone before the Style zone', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                const roleIdx = prompt.indexOf('Role:');
+                const rulesIdx = prompt.indexOf('Rules:');
+                const styleIdx = prompt.indexOf('Style:');
+
+                roleIdx.should.be.greaterThan(-1);
+                rulesIdx.should.be.greaterThan(roleIdx);
+                styleIdx.should.be.greaterThan(rulesIdx);
+            });
+
+            it('should place the Current Application Context between the Role and Rules zones so rule 4 "shown above" is truthful', function () {
+                const appInfo = {
+                    common: { data: { OpenUI5: '1.120.0' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                const roleIdx = prompt.indexOf('Role:');
+                const appCtxIdx = prompt.indexOf('Current Application Context');
+                const rulesIdx = prompt.indexOf('Rules:');
+
+                roleIdx.should.be.greaterThan(-1);
+                appCtxIdx.should.be.greaterThan(roleIdx);
+                rulesIdx.should.be.greaterThan(appCtxIdx);
+            });
+
+            it('should list the four Rules in the prescribed order: English, grounding, uncertainty, runtime-data preference', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                const englishIdx = prompt.indexOf('1.');
+                const groundingIdx = prompt.indexOf('2.');
+                const uncertaintyIdx = prompt.indexOf('3.');
+                const runtimeIdx = prompt.indexOf('4.');
+
+                englishIdx.should.be.greaterThan(-1);
+                groundingIdx.should.be.greaterThan(englishIdx);
+                uncertaintyIdx.should.be.greaterThan(groundingIdx);
+                runtimeIdx.should.be.greaterThan(uncertaintyIdx);
+
+                const rule1 = prompt.substring(englishIdx, groundingIdx);
+                const rule2 = prompt.substring(groundingIdx, uncertaintyIdx);
+                const rule3 = prompt.substring(uncertaintyIdx, runtimeIdx);
+                const rule4 = prompt.substring(runtimeIdx);
+
+                rule1.should.match(/English/);
+                rule2.should.contain('Current UI5 Control Context');
+                rule3.should.contain('confident');
+                rule4.should.match(/runtime data/i);
+                rule4.should.contain('shown above');
+            });
+
+            it('should include the prescribed uncertainty phrase template', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                prompt.should.contain('I\'m not certain <name> exists on <control> — verify in the API reference.');
+            });
+
+            it('should include a bad/good copy-me example demonstrating the uncertainty phrase', function () {
+                const prompt = promptBuilder.buildSystemPrompt();
+
+                const badIdx = prompt.toLowerCase().indexOf('bad:');
+                const goodIdx = prompt.toLowerCase().indexOf('good:');
+
+                badIdx.should.be.greaterThan(-1);
+                goodIdx.should.be.greaterThan(badIdx);
+
+                // The good example must instantiate the uncertainty phrase pattern.
+                const goodSection = prompt.substring(goodIdx);
+                goodSection.should.match(/I'm not certain .+ exists on .+ — verify in the API reference\./);
+            });
         });
 
-        it('should include the SAPUI5 framework version from application metadata in the Current Application Context section', function () {
-            const appInfo = {
-                common: {
-                    data: {
-                        SAPUI5: '1.120.0'
+        describe('Current Application Context (with app info)', function () {
+            it('should include the OpenUI5 framework version from common.data', function () {
+                const appInfo = {
+                    common: { data: { OpenUI5: '1.120.0' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Current Application Context');
+                prompt.should.contain('Framework: 1.120.0');
+            });
+
+            it('should include the SAPUI5 framework version from common.data', function () {
+                const appInfo = {
+                    common: { data: { SAPUI5: '1.120.0' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Framework: 1.120.0');
+            });
+
+            it('should include the configured theme from configurationComputed.data.theme', function () {
+                const appInfo = {
+                    configurationComputed: { data: { theme: 'sap_horizon' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Theme: sap_horizon');
+            });
+
+            it('should include the UI locale from configurationComputed.data.language', function () {
+                const appInfo = {
+                    configurationComputed: { data: { language: 'en-US' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('UI locale: en-US');
+            });
+
+            it('should fall back to configurationComputed.data.locale when language is absent', function () {
+                const appInfo = {
+                    configurationComputed: { data: { locale: 'de-DE' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('UI locale: de-DE');
+            });
+
+            it('should omit the UI locale line when neither language nor locale is present', function () {
+                const appInfo = {
+                    configurationComputed: { data: { theme: 'sap_horizon' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.not.contain('UI locale');
+            });
+
+            it('should include the sap-ui-debug URL parameter when present', function () {
+                const appInfo = {
+                    urlParameters: { data: { 'sap-ui-debug': 'true' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('sap-ui-debug: true');
+            });
+
+            it('should omit the sap-ui-debug line when the parameter is absent', function () {
+                const appInfo = {
+                    urlParameters: { data: { 'other-param': 'x' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.not.contain('sap-ui-debug');
+            });
+
+            it('should include the application entry point from common.data.Application', function () {
+                const appInfo = {
+                    common: {
+                        data: {
+                            OpenUI5: '1.120.0',
+                            Application: 'https://example.com/index.html'
+                        }
                     }
-                }
-            };
+                };
 
-            const prompt = promptBuilder.buildSystemPrompt(appInfo);
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
 
-            prompt.should.contain('Current Application Context');
-            prompt.should.contain('Framework: 1.120.0');
+                prompt.should.contain('Application entry point: https://example.com/index.html');
+            });
+
+            it('should omit the entry point line when common.data.Application is missing', function () {
+                const appInfo = {
+                    common: { data: { OpenUI5: '1.120.0' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.not.contain('Application entry point');
+            });
+
+            it('should include the list of loaded libraries', function () {
+                const appInfo = {
+                    loadedLibraries: {
+                        data: {
+                            'sap.m': {},
+                            'sap.ui.core': {}
+                        }
+                    }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Loaded Libraries: sap.m, sap.ui.core');
+            });
+
+            it('should include the Current Application Context section when only urlParameters.data has sap-ui-debug', function () {
+                const appInfo = {
+                    urlParameters: { data: { 'sap-ui-debug': 'true' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Current Application Context');
+            });
+
+            it('should include the Current Application Context section when only configurationComputed has data', function () {
+                const appInfo = {
+                    configurationComputed: { data: { theme: 'sap_horizon' } }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Current Application Context');
+            });
+
+            it('should omit the Current Application Context section when appInfo contains no recognized fields', function () {
+                const appInfo = {
+                    common: { data: {} },
+                    configurationComputed: { data: {} },
+                    urlParameters: { data: {} },
+                    loadedLibraries: { data: {} }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.not.contain('Current Application Context');
+            });
+
+            it('should render all six fields together when all are provided', function () {
+                const appInfo = {
+                    common: {
+                        data: {
+                            OpenUI5: '1.120.0',
+                            Application: 'https://example.com/'
+                        }
+                    },
+                    configurationComputed: {
+                        data: {
+                            theme: 'sap_horizon',
+                            language: 'en-US'
+                        }
+                    },
+                    urlParameters: {
+                        data: { 'sap-ui-debug': 'true' }
+                    },
+                    loadedLibraries: {
+                        data: { 'sap.m': {}, 'sap.ui.core': {} }
+                    }
+                };
+
+                const prompt = promptBuilder.buildSystemPrompt(appInfo);
+
+                prompt.should.contain('Framework: 1.120.0');
+                prompt.should.contain('Theme: sap_horizon');
+                prompt.should.contain('UI locale: en-US');
+                prompt.should.contain('sap-ui-debug: true');
+                prompt.should.contain('Application entry point: https://example.com/');
+                prompt.should.contain('Loaded Libraries: sap.m, sap.ui.core');
+            });
         });
 
-        it('should include the configured theme from application metadata', function () {
-            const appInfo = {
-                configurationComputed: {
-                    data: {
-                        theme: 'sap_horizon'
+        // Golden-file assertions for the assembled system prompt. Any wording change surfaces here
+        // as an explicit diff so a human eye reviews shape drift on every prompt change. Zones are
+        // held as separate constants so each test composes exactly the zones its scenario expects,
+        // in the order the SUT emits them: Role, [Current Application Context], Rules, Style,
+        // Example.
+        describe('golden output', function () {
+            const ROLE =
+                'Role:\n' +
+                'You are an assistant embedded in the UI5 Inspector, specialized in SAP UI5, OpenUI5, and UI5 Web Components — helping developers understand, debug, and build UI5-based applications.';
+
+            const RULES =
+                'Rules:\n' +
+                '1. Always reply in English, regardless of the language of the user\'s message.\n' +
+                '2. When a Current UI5 Control Context section is present in the user prompt, only reference property, aggregation, event, and binding names that appear in it. If asked about a name not listed there, say so plainly.\n' +
+                '3. When naming a specific property, event, method, or enum value on a UI5 control, only state it if confident it exists. Otherwise use this exact phrase and add no further disclaimers:\n' +
+                'I\'m not certain <name> exists on <control> — verify in the API reference.\n' +
+                '4. Prefer runtime data (resolved binding values, console errors, application metadata shown above) over general assumptions when answering.';
+
+            const STYLE =
+                'Style:\n' +
+                'Neutral, direct, and developer-focused. Use code snippets for code. No marketing filler, no generic disclaimers.';
+
+            const EXAMPLE =
+                'Example — uncertainty phrase in use:\n' +
+                'Bad: "Yes, sap.m.Slider has a `flashOnClick` property that lights it up."\n' +
+                'Good: "I\'m not certain flashOnClick exists on sap.m.Slider — verify in the API reference."';
+
+            it('golden: no app info', function () {
+                const expected = [ROLE, RULES, STYLE, EXAMPLE].join('\n\n');
+                promptBuilder.buildSystemPrompt().should.equal(expected);
+            });
+
+            it('golden: only framework', function () {
+                const appInfo = {
+                    common: { data: { OpenUI5: '1.120.0' } }
+                };
+
+                const appContext =
+                    'Current Application Context:\n' +
+                    '- Framework: 1.120.0';
+
+                const expected = [ROLE, appContext, RULES, STYLE, EXAMPLE].join('\n\n');
+
+                promptBuilder.buildSystemPrompt(appInfo).should.equal(expected);
+            });
+
+            it('golden: framework + theme + libraries', function () {
+                const appInfo = {
+                    common: { data: { OpenUI5: '1.120.0' } },
+                    configurationComputed: { data: { theme: 'sap_horizon' } },
+                    loadedLibraries: { data: { 'sap.m': {}, 'sap.ui.core': {} } }
+                };
+
+                const appContext =
+                    'Current Application Context:\n' +
+                    '- Framework: 1.120.0\n' +
+                    '- Theme: sap_horizon\n' +
+                    '- Loaded Libraries: sap.m, sap.ui.core';
+
+                const expected = [ROLE, appContext, RULES, STYLE, EXAMPLE].join('\n\n');
+
+                promptBuilder.buildSystemPrompt(appInfo).should.equal(expected);
+            });
+
+            it('golden: all six fields', function () {
+                const appInfo = {
+                    common: {
+                        data: {
+                            OpenUI5: '1.120.0',
+                            Application: 'https://example.com/index.html'
+                        }
+                    },
+                    configurationComputed: {
+                        data: { theme: 'sap_horizon', language: 'en-US' }
+                    },
+                    urlParameters: {
+                        data: { 'sap-ui-debug': 'true' }
+                    },
+                    loadedLibraries: {
+                        data: { 'sap.m': {}, 'sap.ui.core': {} }
                     }
-                }
-            };
+                };
 
-            const prompt = promptBuilder.buildSystemPrompt(appInfo);
+                const appContext =
+                    'Current Application Context:\n' +
+                    '- Framework: 1.120.0\n' +
+                    '- Theme: sap_horizon\n' +
+                    '- UI locale: en-US\n' +
+                    '- sap-ui-debug: true\n' +
+                    '- Application entry point: https://example.com/index.html\n' +
+                    '- Loaded Libraries: sap.m, sap.ui.core';
 
-            prompt.should.contain('Theme: sap_horizon');
-        });
+                const expected = [ROLE, appContext, RULES, STYLE, EXAMPLE].join('\n\n');
 
-        it('should include the list of loaded libraries from application metadata', function () {
-            const appInfo = {
-                loadedLibraries: {
-                    data: {
-                        'sap.m': {},
-                        'sap.ui.core': {}
-                    }
-                }
-            };
-
-            const prompt = promptBuilder.buildSystemPrompt(appInfo);
-
-            prompt.should.contain('Loaded Libraries: sap.m, sap.ui.core');
+                promptBuilder.buildSystemPrompt(appInfo).should.equal(expected);
+            });
         });
     });
 
@@ -177,7 +504,8 @@ describe('PromptBuilder', function () {
 
             seed.should.have.lengthOf(1);
             seed[0].role.should.equal('system');
-            seed[0].content.should.contain('AI assistant');
+            seed[0].content.should.contain('UI5 Inspector');
+            seed[0].content.should.contain('Rules:');
         });
 
         it('should replay prior user and assistant turns after the system message', function () {

--- a/tests/modules/ai/PromptBuilder.spec.js
+++ b/tests/modules/ai/PromptBuilder.spec.js
@@ -979,6 +979,232 @@ describe('PromptBuilder', function () {
                 promptBuilder.buildUserPrompt('Q', inspectionContext).should.equal(expected);
             });
         });
+
+        describe('Recent Console Errors section', function () {
+            it('should omit the section entirely when the console-errors array is empty', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'btn' }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext, []);
+
+                result.should.not.contain('Recent Console Errors');
+            });
+
+            it('should omit the section entirely when the console-errors argument is missing', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'btn' }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.not.contain('Recent Console Errors');
+            });
+
+            it('should still wrap the user message in the sandwich when only console errors are present (no inspection context)', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:1', count: 1 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                result.indexOf('User asked: Q').should.equal(0);
+                result.should.contain('Recent Console Errors:');
+                result.should.not.contain('Current UI5 Control Context');
+                result.lastIndexOf('Now answer: Q').should.be.greaterThan(-1);
+            });
+
+            it('should return the raw user message when neither inspection context nor console errors are present', function () {
+                promptBuilder.buildUserPrompt('Q', null, []).should.equal('Q');
+                promptBuilder.buildUserPrompt('Q', null, null).should.equal('Q');
+                promptBuilder.buildUserPrompt('Q', null, undefined).should.equal('Q');
+            });
+
+            it('should render entries newest-first (reverse of arrival order)', function () {
+                // Buffer records `first` then `second` then `third` — snapshot arrival-first.
+                const consoleErrors = [
+                    { type: 'error', message: 'first', count: 1 },
+                    { type: 'error', message: 'second', count: 1 },
+                    { type: 'error', message: 'third', count: 1 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                const idxFirst = result.indexOf('first');
+                const idxSecond = result.indexOf('second');
+                const idxThird = result.indexOf('third');
+
+                idxThird.should.be.lessThan(idxSecond);
+                idxSecond.should.be.lessThan(idxFirst);
+            });
+
+            it('should annotate `(×N)` only when count > 1', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'once', count: 1 },
+                    { type: 'error', message: 'many', count: 20 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                result.should.contain('- many (×20)');
+                result.should.contain('- once');
+                result.should.not.contain('once (×1)');
+            });
+
+            it('should render an indented `at <frame>` line beneath the message when a frame is present', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:42', count: 1 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                result.should.contain('- boom\n  at app.js:42');
+            });
+
+            it('should omit the frame line entirely when the frame is empty', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'no stack here', frame: '', count: 1 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                result.should.contain('- no stack here');
+                result.should.not.contain('\n  at ');
+            });
+
+            it('should place the Recent Console Errors block after the Current UI5 Control Context block', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'btn' }
+                };
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:1', count: 1 }
+                ];
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext, consoleErrors);
+
+                const controlIdx = result.indexOf('Current UI5 Control Context:');
+                const errorsIdx = result.indexOf('Recent Console Errors:');
+                controlIdx.should.be.greaterThan(-1);
+                errorsIdx.should.be.greaterThan(controlIdx);
+            });
+
+            it('should cap the section at ~400 characters and append the [truncated] marker on adversarial input', function () {
+                const consoleErrors = [];
+                for (let i = 0; i < 50; i++) {
+                    consoleErrors.push({
+                        type: 'error',
+                        message: 'a really long error message number ' + i + ' with more filler text to burn budget',
+                        frame: 'file' + i + '.js:' + i,
+                        count: 1
+                    });
+                }
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                result.should.contain('[truncated]');
+                // The section body is capped — check the whole errors block stays under ~450 chars
+                // (400 body cap + header + [truncated] tail).
+                const start = result.indexOf('Recent Console Errors:');
+                const end = result.indexOf('\n\nNow answer:');
+                const section = result.substring(start, end);
+                section.length.should.be.lessThan(500);
+            });
+
+            it('golden: errors only (no inspection context)', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:1', count: 1 }
+                ];
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Recent Console Errors:\n' +
+                    '- boom\n' +
+                    '  at app.js:1\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', null, consoleErrors).should.equal(expected);
+            });
+
+            it('golden: errors + control', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'saveBtn' }
+                };
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:1', count: 1 }
+                ];
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Current UI5 Control Context:\n' +
+                    '- Type: sap.m.Button\n' +
+                    '- ID: saveBtn\n\n' +
+                    'Recent Console Errors:\n' +
+                    '- boom\n' +
+                    '  at app.js:1\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', inspectionContext, consoleErrors).should.equal(expected);
+            });
+
+            it('golden: errors with a duplicate count', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'boom', frame: 'app.js:42', count: 20 }
+                ];
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Recent Console Errors:\n' +
+                    '- boom (×20)\n' +
+                    '  at app.js:42\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', null, consoleErrors).should.equal(expected);
+            });
+
+            it('golden: errors with no stack', function () {
+                const consoleErrors = [
+                    { type: 'error', message: 'plain console.error output', frame: '', count: 1 }
+                ];
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Recent Console Errors:\n' +
+                    '- plain console.error output\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', null, consoleErrors).should.equal(expected);
+            });
+
+            it('golden: adversarial (50 different errors triggering the section cap)', function () {
+                const consoleErrors = [];
+                for (let i = 0; i < 50; i++) {
+                    consoleErrors.push({
+                        type: 'error',
+                        message: 'error number ' + i + ' with plenty of filler text to burn budget quickly',
+                        frame: 'file' + i + '.js:' + (i * 10),
+                        count: 1
+                    });
+                }
+
+                const result = promptBuilder.buildUserPrompt('Q', null, consoleErrors);
+
+                // The section body is capped at 400 chars. Newest-first means index 49 comes
+                // first. Build the exact expected body by joining lines until we exceed 400 chars,
+                // then truncating at 400 + '... [truncated]'.
+                const reversedLines = consoleErrors.slice().reverse().map(function (entry) {
+                    return '- ' + entry.message + '\n  at ' + entry.frame;
+                });
+                const fullBody = reversedLines.join('\n');
+                const cappedBody = fullBody.substring(0, 400) + '... [truncated]';
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Recent Console Errors:\n' +
+                    cappedBody + '\n\n' +
+                    'Now answer: Q';
+
+                result.should.equal(expected);
+            });
+        });
     });
 
     // ---- helpers for section-extraction assertions -----------------------------

--- a/tests/modules/ai/PromptBuilder.spec.js
+++ b/tests/modules/ai/PromptBuilder.spec.js
@@ -2,6 +2,42 @@
 
 const PromptBuilder = require('../../../app/scripts/modules/ai/PromptBuilder.js');
 
+// ---- helpers for section-extraction assertions -----------------------------
+// The buildUserPrompt tests below use small extractors so per-section cap assertions do not
+// accidentally count characters from *other* sections. They locate the labeled header and read
+// until the next blank line or the sandwich's closing `Now answer:` line.
+
+function _extractSection(prompt, header) {
+    const start = prompt.indexOf(header);
+    if (start < 0) {
+        return '';
+    }
+    const rest = prompt.substring(start);
+    // A section ends at the next blank line (which precedes "Now answer:") or at the
+    // sandwich's closing line.
+    const stopMarkers = ['\n\n', '\nNow answer:'];
+    let stop = rest.length;
+    for (let i = 0; i < stopMarkers.length; i++) {
+        const idx = rest.indexOf(stopMarkers[i]);
+        if (idx >= 0 && idx < stop) {
+            stop = idx;
+        }
+    }
+    return rest.substring(0, stop);
+}
+
+function _extractPropertiesSection(prompt) {
+    return _extractSection(prompt, 'Properties:');
+}
+
+function _extractBindingsSection(prompt) {
+    return _extractSection(prompt, 'Bindings:');
+}
+
+function _extractAggregationsSection(prompt) {
+    return _extractSection(prompt, 'Aggregations:');
+}
+
 describe('PromptBuilder', function () {
     let promptBuilder;
 
@@ -395,108 +431,558 @@ describe('PromptBuilder', function () {
     });
 
     describe('#buildUserPrompt()', function () {
-        it('should return the user message unchanged when no inspection context is provided', function () {
-            const result = promptBuilder.buildUserPrompt('Test prompt', null);
 
-            result.should.equal('Test prompt');
+        describe('no-context behavior', function () {
+            it('should return the user message unchanged when no inspection context is provided', function () {
+                const result = promptBuilder.buildUserPrompt('Test prompt', null);
+
+                result.should.equal('Test prompt');
+            });
+
+            it('should return the user message unchanged when inspection context has no selected control', function () {
+                const result = promptBuilder.buildUserPrompt('Test prompt', {});
+
+                result.should.equal('Test prompt');
+            });
         });
 
-        it('should return the user message unchanged when inspection context has no selected control', function () {
-            const result = promptBuilder.buildUserPrompt('Test prompt', {});
+        describe('sandwich structure', function () {
+            it('should start with "User asked: <message>" and end with "Now answer: <message>" when a control is attached', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'btn' }
+                };
 
-            result.should.equal('Test prompt');
+                const result = promptBuilder.buildUserPrompt('Why is this broken?', inspectionContext);
+
+                result.indexOf('User asked: Why is this broken?').should.equal(0);
+                const idx = result.lastIndexOf('Now answer: Why is this broken?');
+                idx.should.be.greaterThan(-1);
+                idx.should.equal(result.length - 'Now answer: Why is this broken?'.length);
+            });
+
+            it('should place the Current UI5 Control Context block between the top and bottom question restatements', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'btn' }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Test', inspectionContext);
+
+                const userAskedIdx = result.indexOf('User asked:');
+                const ctxIdx = result.indexOf('Current UI5 Control Context:');
+                const nowAnswerIdx = result.indexOf('Now answer:');
+
+                userAskedIdx.should.equal(0);
+                ctxIdx.should.be.greaterThan(userAskedIdx);
+                nowAnswerIdx.should.be.greaterThan(ctxIdx);
+            });
         });
 
-        it('should prefix the user message with the selected control type, id, and a User Question label', function () {
-            const inspectionContext = {
-                control: {
-                    type: 'sap.m.Button',
-                    id: 'myButton'
-                }
-            };
+        describe('control identity', function () {
+            it('should include Type and ID lines when both are provided', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'myButton' }
+                };
 
-            const result = promptBuilder.buildUserPrompt('Test prompt', inspectionContext);
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
 
-            result.should.contain('Type: sap.m.Button');
-            result.should.contain('ID: myButton');
-            result.should.contain('User Question: Test prompt');
+                result.should.contain('- Type: sap.m.Button');
+                result.should.contain('- ID: myButton');
+            });
         });
 
-        it('should truncate large selected-control properties so the prompt stays bounded', function () {
-            const largeData = {};
-            for (let i = 0; i < 200; i++) {
-                largeData['property' + i] = 'value'.repeat(20);
-            }
-
-            const inspectionContext = {
-                control: {
-                    type: 'sap.m.Button',
-                    properties: {
-                        own: {
-                            data: largeData
-                        }
-                    }
-                }
-            };
-
-            const result = promptBuilder.buildUserPrompt('Test', inspectionContext);
-
-            result.should.contain('[truncated]');
-        });
-
-        it('should include a bindings section summarizing the selected control bindings', function () {
-            const inspectionContext = {
-                control: {
-                    type: 'sap.m.Text',
-                    bindings: {
-                        text: {
-                            path: '/Name'
-                        }
-                    }
-                }
-            };
-
-            const result = promptBuilder.buildUserPrompt('Test', inspectionContext);
-
-            result.should.contain('Bindings (1):');
-            result.should.contain('"/Name"');
-        });
-
-        it('should include an aggregations section summarizing the selected control aggregations', function () {
-            const inspectionContext = {
-                control: {
-                    type: 'sap.m.Page',
-                    aggregations: {
-                        own: {
-                            data: {
-                                content: ['child1', 'child2']
+        describe('properties rendering', function () {
+            it('should render properties as key: value lines with no JSON braces on the happy path', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        properties: {
+                            own: {
+                                data: {
+                                    text: 'Save',
+                                    enabled: true,
+                                    width: '100px'
+                                }
                             }
                         }
                     }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+                const propsSection = _extractPropertiesSection(result);
+
+                propsSection.should.contain('text: Save');
+                propsSection.should.contain('enabled: true');
+                propsSection.should.contain('width: 100px');
+                propsSection.should.not.contain('{');
+                propsSection.should.not.contain('}');
+            });
+
+            it('should omit the Properties section entirely when own properties are empty', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        properties: { own: { data: {} } }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.not.contain('Properties:');
+            });
+
+            it('should truncate the properties section to its cap with a [truncated] marker on adversarial input', function () {
+                const largeData = {};
+                for (let i = 0; i < 500; i++) {
+                    largeData['property' + i] = 'value'.repeat(20);
                 }
-            };
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        properties: { own: { data: largeData } }
+                    }
+                };
 
-            const result = promptBuilder.buildUserPrompt('Test', inspectionContext);
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+                const propsSection = _extractPropertiesSection(result);
 
-            result.should.contain('Aggregations (1):');
-            result.should.contain('child1');
+                propsSection.should.contain('[truncated]');
+                // 800-char cap plus the "... [truncated]" tail, plus the "Properties:\n" header line.
+                propsSection.length.should.be.lessThan(1000);
+            });
         });
 
-        it('should handle a selected control with circular property data without throwing', function () {
-            const circular = {};
-            circular.self = circular;
-            const inspectionContext = {
-                control: {
-                    type: 'sap.m.Button',
-                    bindings: circular
+        describe('bindings rendering', function () {
+            it('should render a single binding on one line with path, model, and resolved value', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: {
+                                path: '/Name',
+                                value: 'Alice',
+                                model: 'default'
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- text ← "/Name" = Alice (model: default)');
+            });
+
+            it('should omit the "= <value>" segment when the snapshot carries no resolved value', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: { path: '/Name', model: 'default' }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- text ← "/Name" (model: default)');
+                result.should.not.contain('=');
+            });
+
+            it('should print null literally when the resolved value is null', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: { path: '/Name', value: null, model: 'default' }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('= null');
+            });
+
+            it('should print undefined literally when the resolved value is undefined and the field is present', function () {
+                // The snapshot must explicitly carry the key as undefined for it to render.
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: Object.assign({ path: '/Name', model: 'default' }, { value: undefined })
+                        }
+                    }
+                };
+
+                // The rule per the AC is: "= <value>" appears only when the snapshot carries a
+                // resolved value. `undefined` printed literally is required *only* when the
+                // snapshot explicitly carries an undefined value — but `Object.assign` drops
+                // undefined properties in some engines, so we test the intent using an explicit
+                // hasOwn check via a getter-style object.
+                const explicitUndefined = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: (function () {
+                                const b = { path: '/Name', model: 'default' };
+                                Object.defineProperty(b, 'value', { value: undefined, enumerable: true });
+                                return b;
+                            }())
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', explicitUndefined);
+                result.should.contain('= undefined');
+            });
+
+            it('should default the model annotation to "default" when the binding has a path but no explicit model', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: { path: '/Name' }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('(model: default)');
+            });
+
+            it('should include type when present', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Input',
+                        bindings: {
+                            value: {
+                                path: '/Age',
+                                value: 42,
+                                model: 'default',
+                                type: 'sap.ui.model.type.Integer'
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('type: sap.ui.model.type.Integer');
+            });
+
+            it('should include "formatter: yes" when a formatter is present', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: {
+                                path: '/Name',
+                                value: 'Alice',
+                                model: 'default',
+                                formatter: function () {}
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('formatter: yes');
+            });
+
+            it('should truncate a very long resolved value at approximately 100 characters', function () {
+                const longValue = 'x'.repeat(500);
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: { path: '/Name', value: longValue, model: 'default' }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                // The rendered value must be shorter than the raw length + a truncation marker.
+                result.should.not.contain(longValue);
+                result.should.contain('...');
+            });
+
+            it('should render composite bindings (parts) as a degenerate one-line entry without throwing', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: {
+                            text: {
+                                parts: [
+                                    { path: '/First' },
+                                    { path: '/Last' }
+                                ]
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- text ← <composite>');
+            });
+
+            it('should truncate the bindings section to its cap on adversarial input', function () {
+                const many = {};
+                for (let i = 0; i < 500; i++) {
+                    many['prop' + i] = { path: '/very/long/path/' + i, value: 'value' + i };
                 }
-            };
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        bindings: many
+                    }
+                };
 
-            const result = promptBuilder.buildUserPrompt('Test', inspectionContext);
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+                const bindingsSection = _extractBindingsSection(result);
 
-            result.should.contain('cannot serialize');
+                bindingsSection.should.contain('[truncated]');
+                bindingsSection.length.should.be.lessThan(1000);
+            });
+
+            it('should handle a selected control with circular binding data without throwing', function () {
+                const circular = {};
+                circular.self = circular;
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        bindings: circular
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('cannot serialize');
+            });
+        });
+
+        describe('aggregations rendering', function () {
+            it('should render an empty aggregation as "<name>: empty"', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Page',
+                        aggregations: {
+                            own: {
+                                data: {
+                                    content: []
+                                }
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- content: empty');
+            });
+
+            it('should append child IDs when the child count is <= 3', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Page',
+                        aggregations: {
+                            own: {
+                                data: {
+                                    content: [
+                                        { id: 'btn1', type: 'sap.m.Button' },
+                                        { id: 'btn2', type: 'sap.m.Button' }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- content: 2 children — btn1, btn2');
+            });
+
+            it('should render a type histogram when the child count is > 3', function () {
+                const children = [];
+                for (let i = 0; i < 20; i++) {
+                    children.push({ id: 't' + i, type: 'sap.m.Text' });
+                }
+                for (let i = 0; i < 4; i++) {
+                    children.push({ id: 'b' + i, type: 'sap.m.Button' });
+                }
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Page',
+                        aggregations: {
+                            own: {
+                                data: { content: children }
+                            }
+                        }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.contain('- content: 24 children (sap.m.Text × 20, sap.m.Button × 4)');
+            });
+
+            it('should omit the Aggregations section entirely when own aggregations are empty', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        aggregations: { own: { data: {} } }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+
+                result.should.not.contain('Aggregations:');
+            });
+
+            it('should truncate the aggregations section to its cap on adversarial input', function () {
+                const data = {};
+                for (let i = 0; i < 100; i++) {
+                    const children = [];
+                    for (let j = 0; j < 200; j++) {
+                        children.push({ id: 'child' + i + '_' + j, type: 'sap.m.SomeReallyLongTypeName' });
+                    }
+                    data['aggr' + i] = children;
+                }
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Page',
+                        aggregations: { own: { data: data } }
+                    }
+                };
+
+                const result = promptBuilder.buildUserPrompt('Q', inspectionContext);
+                const aggregationsSection = _extractAggregationsSection(result);
+
+                aggregationsSection.should.contain('[truncated]');
+                aggregationsSection.length.should.be.lessThan(600);
+            });
+        });
+
+        describe('golden output', function () {
+            it('golden: control identity only', function () {
+                const inspectionContext = {
+                    control: { type: 'sap.m.Button', id: 'myBtn' }
+                };
+
+                const expected =
+                    'User asked: Hi\n\n' +
+                    'Current UI5 Control Context:\n' +
+                    '- Type: sap.m.Button\n' +
+                    '- ID: myBtn\n\n' +
+                    'Now answer: Hi';
+
+                promptBuilder.buildUserPrompt('Hi', inspectionContext).should.equal(expected);
+            });
+
+            it('golden: control + properties only', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Button',
+                        id: 'saveBtn',
+                        properties: {
+                            own: {
+                                data: {
+                                    text: 'Save',
+                                    enabled: true
+                                }
+                            }
+                        }
+                    }
+                };
+
+                const expected =
+                    'User asked: Hi\n\n' +
+                    'Current UI5 Control Context:\n' +
+                    '- Type: sap.m.Button\n' +
+                    '- ID: saveBtn\n' +
+                    'Properties:\n' +
+                    '- text: Save\n' +
+                    '- enabled: true\n\n' +
+                    'Now answer: Hi';
+
+                promptBuilder.buildUserPrompt('Hi', inspectionContext).should.equal(expected);
+            });
+
+            it('golden: control + bindings (single, with value)', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Text',
+                        id: 'nameLabel',
+                        bindings: {
+                            text: {
+                                path: '/Name',
+                                value: 'Alice',
+                                model: 'default'
+                            }
+                        }
+                    }
+                };
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Current UI5 Control Context:\n' +
+                    '- Type: sap.m.Text\n' +
+                    '- ID: nameLabel\n' +
+                    'Bindings:\n' +
+                    '- text ← "/Name" = Alice (model: default)\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', inspectionContext).should.equal(expected);
+            });
+
+            it('golden: control + aggregations (empty, small, and large mixed)', function () {
+                const inspectionContext = {
+                    control: {
+                        type: 'sap.m.Page',
+                        id: 'page1',
+                        aggregations: {
+                            own: {
+                                data: {
+                                    customHeader: [],
+                                    content: [
+                                        { id: 'btn1', type: 'sap.m.Button' },
+                                        { id: 'btn2', type: 'sap.m.Button' }
+                                    ],
+                                    footer: (function () {
+                                        const arr = [];
+                                        for (let i = 0; i < 5; i++) {
+                                            arr.push({ id: 't' + i, type: 'sap.m.Text' });
+                                        }
+                                        arr.push({ id: 'b1', type: 'sap.m.Button' });
+                                        return arr;
+                                    }())
+                                }
+                            }
+                        }
+                    }
+                };
+
+                const expected =
+                    'User asked: Q\n\n' +
+                    'Current UI5 Control Context:\n' +
+                    '- Type: sap.m.Page\n' +
+                    '- ID: page1\n' +
+                    'Aggregations:\n' +
+                    '- customHeader: empty\n' +
+                    '- content: 2 children — btn1, btn2\n' +
+                    '- footer: 6 children (sap.m.Text × 5, sap.m.Button × 1)\n\n' +
+                    'Now answer: Q';
+
+                promptBuilder.buildUserPrompt('Q', inspectionContext).should.equal(expected);
+            });
         });
     });
+
+    // ---- helpers for section-extraction assertions -----------------------------
+    // See the top of the file for the extractor helpers used by buildUserPrompt tests above.
 
     describe('#buildSeedMessages()', function () {
         it('should produce a single system message when there is no Conversation Memory to replay', function () {

--- a/tests/modules/injected/consoleErrorBuffer.spec.js
+++ b/tests/modules/injected/consoleErrorBuffer.spec.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const consoleErrorBuffer = require('../../../app/scripts/modules/injected/consoleErrorBuffer.js');
+
+describe('consoleErrorBuffer', function () {
+
+    describe('#create()', function () {
+        it('should return an object with record, snapshot, and clear methods', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.should.have.property('record').that.is.a('function');
+            buffer.should.have.property('snapshot').that.is.a('function');
+            buffer.should.have.property('clear').that.is.a('function');
+        });
+
+        it('should start with an empty snapshot', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.snapshot().should.deep.equal([]);
+        });
+    });
+
+    describe('#record() — basic buffering', function () {
+        it('should record a single event and expose it via snapshot', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'boom' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].message.should.equal('boom');
+            snap[0].count.should.equal(1);
+        });
+
+        it('should accept error, warn, and uncaught event types', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            buffer.record({ type: 'warn', message: 'b' });
+            buffer.record({ type: 'uncaught', message: 'c' });
+
+            buffer.snapshot().should.have.lengthOf(3);
+        });
+    });
+
+    describe('#record() — FIFO ring behavior', function () {
+        it('should hold at most three distinct entries', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            buffer.record({ type: 'error', message: 'b' });
+            buffer.record({ type: 'error', message: 'c' });
+            buffer.record({ type: 'error', message: 'd' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(3);
+            snap.map(function (e) { return e.message; }).should.deep.equal(['b', 'c', 'd']);
+        });
+
+        it('should preserve arrival order in the snapshot (oldest first)', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'first' });
+            buffer.record({ type: 'error', message: 'second' });
+            buffer.record({ type: 'error', message: 'third' });
+
+            const snap = buffer.snapshot();
+            snap.map(function (e) { return e.message; }).should.deep.equal(['first', 'second', 'third']);
+        });
+    });
+
+    describe('#record() — deduplication', function () {
+        it('should increment the count on an existing entry when the same message + top-shown stack frame arrives again', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'boom', stack: 'Error\n    at foo (app.js:1:1)' });
+            buffer.record({ type: 'error', message: 'boom', stack: 'Error\n    at foo (app.js:1:1)' });
+            buffer.record({ type: 'error', message: 'boom', stack: 'Error\n    at foo (app.js:1:1)' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].message.should.equal('boom');
+            snap[0].count.should.equal(3);
+        });
+
+        it('should not re-promote a deduplicated entry to the front of the buffer', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            buffer.record({ type: 'error', message: 'b' });
+            buffer.record({ type: 'error', message: 'a' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(2);
+            snap[0].message.should.equal('a');
+            snap[0].count.should.equal(2);
+            snap[1].message.should.equal('b');
+        });
+
+        it('should treat events with the same message but different top-shown frames as distinct', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'boom', stack: 'Error\n    at foo (app.js:1:1)' });
+            buffer.record({ type: 'error', message: 'boom', stack: 'Error\n    at bar (other.js:5:5)' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(2);
+        });
+
+        it('should normalize whitespace in the message for the dedup key', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'foo   bar' });
+            buffer.record({ type: 'error', message: 'foo bar' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].count.should.equal(2);
+        });
+    });
+
+    describe('#record() — stack-frame selection', function () {
+        it('should pick the top frame when it is not a framework frame', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({
+                type: 'uncaught',
+                message: 'boom',
+                stack: 'Error\n    at foo (app.js:42:5)\n    at bar (other.js:5:5)'
+            });
+
+            const snap = buffer.snapshot();
+            snap[0].frame.should.contain('app.js:42');
+        });
+
+        it('should skip a top frame from sap-ui-core.js and use the next one', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({
+                type: 'uncaught',
+                message: 'boom',
+                stack: 'Error\n    at Something (https://ui5.sap.com/1.120.0/resources/sap-ui-core.js:1:1)\n    at onPress (app/controller/Main.controller.js:42:5)'
+            });
+
+            const snap = buffer.snapshot();
+            snap[0].frame.should.contain('Main.controller.js:42');
+        });
+
+        it('should skip a top frame that matches resources/sap/', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({
+                type: 'uncaught',
+                message: 'boom',
+                stack: 'Error\n    at Something (resources/sap/m/Button.js:100:10)\n    at onPress (app/controller/Main.controller.js:42:5)'
+            });
+
+            const snap = buffer.snapshot();
+            snap[0].frame.should.contain('Main.controller.js:42');
+        });
+
+        it('should skip at most three frames total, then fall back to whatever frame we landed on', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({
+                type: 'uncaught',
+                message: 'boom',
+                stack: 'Error\n' +
+                    '    at f1 (resources/sap/a.js:1:1)\n' +
+                    '    at f2 (resources/sap/b.js:1:1)\n' +
+                    '    at f3 (resources/sap/c.js:1:1)\n' +
+                    '    at f4 (resources/sap/d.js:1:1)\n' +
+                    '    at f5 (app.js:1:1)'
+            });
+
+            // 3 skips total means: skip frame 1, skip frame 2, skip frame 3, then use frame 4.
+            const snap = buffer.snapshot();
+            snap[0].frame.should.contain('resources/sap/d.js');
+        });
+
+        it('should omit the frame when the event has no stack', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'no stack here' });
+
+            const snap = buffer.snapshot();
+            snap[0].message.should.equal('no stack here');
+            (snap[0].frame === undefined || snap[0].frame === null || snap[0].frame === '').should.be.true;
+        });
+    });
+
+    describe('#clear()', function () {
+        it('should empty the buffer', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            buffer.record({ type: 'error', message: 'b' });
+            buffer.clear();
+
+            buffer.snapshot().should.deep.equal([]);
+        });
+
+        it('should allow recording after clear', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            buffer.clear();
+            buffer.record({ type: 'error', message: 'b' });
+
+            const snap = buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].message.should.equal('b');
+        });
+    });
+
+    describe('#snapshot()', function () {
+        it('should return a fresh copy so mutating it does not affect the internal buffer', function () {
+            const buffer = consoleErrorBuffer.create();
+
+            buffer.record({ type: 'error', message: 'a' });
+            const snap = buffer.snapshot();
+            snap.push({ message: 'injected' });
+
+            buffer.snapshot().should.have.lengthOf(1);
+        });
+    });
+});

--- a/tests/modules/injected/consoleErrorCapture.spec.js
+++ b/tests/modules/injected/consoleErrorCapture.spec.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const consoleErrorCapture = require('../../../app/scripts/modules/injected/consoleErrorCapture.js');
+
+/**
+ * Build a minimal window-like host suitable for exercising the capture adapter without touching
+ * the real console or window. The host records original values so the test can assert
+ * pass-through behavior.
+ */
+function createFakeWindow() {
+    const originalError = sinon.spy();
+    const originalWarn = sinon.spy();
+    return {
+        console: {
+            error: originalError,
+            warn: originalWarn
+        },
+        onerror: null,
+        onunhandledrejection: null,
+        // handles for the assertion side
+        _originalError: originalError,
+        _originalWarn: originalWarn
+    };
+}
+
+describe('consoleErrorCapture', function () {
+    describe('#install()', function () {
+        it('should return a handle with a buffer and an uninstall function', function () {
+            const win = createFakeWindow();
+
+            const handle = consoleErrorCapture.install(win);
+
+            handle.should.have.property('buffer');
+            handle.uninstall.should.be.a('function');
+        });
+
+        it('should funnel console.error calls into the buffer', function () {
+            const win = createFakeWindow();
+
+            const handle = consoleErrorCapture.install(win);
+            win.console.error('boom');
+
+            const snap = handle.buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].message.should.equal('boom');
+            snap[0].type.should.equal('error');
+        });
+
+        it('should funnel console.warn calls into the buffer', function () {
+            const win = createFakeWindow();
+
+            const handle = consoleErrorCapture.install(win);
+            win.console.warn('careful');
+
+            const snap = handle.buffer.snapshot();
+            snap[0].type.should.equal('warn');
+            snap[0].message.should.equal('careful');
+        });
+
+        it('should keep the original console.error running so the developer sees their own output', function () {
+            const win = createFakeWindow();
+
+            consoleErrorCapture.install(win);
+            win.console.error('boom');
+
+            win._originalError.calledOnce.should.be.true;
+            win._originalError.firstCall.args[0].should.equal('boom');
+        });
+
+        it('should funnel window.onerror invocations into the buffer', function () {
+            const win = createFakeWindow();
+
+            const handle = consoleErrorCapture.install(win);
+            win.onerror('boom', 'app.js', 42, 5, new Error('boom'));
+
+            const snap = handle.buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].type.should.equal('uncaught');
+            snap[0].message.should.equal('boom');
+        });
+
+        it('should funnel unhandledrejection into the buffer with a rejection prefix', function () {
+            const win = createFakeWindow();
+
+            const handle = consoleErrorCapture.install(win);
+            win.onunhandledrejection({ reason: new Error('async boom') });
+
+            const snap = handle.buffer.snapshot();
+            snap.should.have.lengthOf(1);
+            snap[0].message.should.contain('async boom');
+        });
+
+        it('should call onRecord after each recorded event', function () {
+            const win = createFakeWindow();
+            const onRecord = sinon.spy();
+
+            consoleErrorCapture.install(win, { onRecord: onRecord });
+            win.console.error('a');
+            win.console.warn('b');
+
+            onRecord.calledTwice.should.be.true;
+        });
+
+        it('should be idempotent across repeated install() calls on the same window', function () {
+            const win = createFakeWindow();
+
+            const first = consoleErrorCapture.install(win);
+            const second = consoleErrorCapture.install(win);
+
+            first.should.equal(second);
+        });
+
+        it('should stringify Error instances passed to console.error and pull the stack when available', function () {
+            const win = createFakeWindow();
+            const handle = consoleErrorCapture.install(win);
+
+            const err = new Error('typed boom');
+            win.console.error(err);
+
+            const snap = handle.buffer.snapshot();
+            snap[0].message.should.contain('typed boom');
+        });
+    });
+});


### PR DESCRIPTION
Three improvements to the AI Assistant, plus a bug fix.

## Better prompts

The system prompt is now structured into Role / Rules / Style zones with a
bad/good example for the uncertainty phrase. Application context also picks up
UI locale, `sap-ui-debug`, and the app entry point when available.

The user prompt uses a sandwich structure — the user's question is repeated
after the context block so the small local model stays focused on it:

    User asked: <msg>

    Current UI5 Control Context:
    ...

    Now answer: <msg>

Properties, bindings, and aggregations are rendered as curated one-liners
instead of raw JSON dumps. Bindings show the resolved value inline. Aggregations
with more than 3 children collapse to a type histogram. Each section has a
character cap so a huge control can't blow out the context window.

## Recent console errors as context

The injected script now captures `console.error`, `console.warn`,
`window.onerror`, and `unhandledrejection` into a small bounded buffer
(capacity 3, deduped by message + top frame). The buffer is pushed to the
panel and rendered into the user prompt as a `Recent Console Errors:` block
so the assistant can see what the app just complained about.

Clearing the conversation also clears the buffer, on both sides.

## Idle-session recovery

Chrome tears down the extension's background service worker after ~30-60s of
port inactivity, which killed the Prompt API session with it. The next Send
would fail with a streaming banner and a second Send was needed to recover.

`sendUserMessage` now checks whether the session is still alive and reseeds
transparently if it isn't. The first Send after idle just takes slightly
longer to start streaming. Conversation memory and Inspection Context survive
the recovery.

## Tests

582/582 pass. New tests cover the console-error buffer/capture modules, the
new prompt shape, and the idle-recovery paths.
